### PR TITLE
[Internal] fix react bridge so that it can be reused.

### DIFF
--- a/sdk/OoyalaSkinSDK/OoyalaSkinSDK/OOReactBridge.h
+++ b/sdk/OoyalaSkinSDK/OoyalaSkinSDK/OOReactBridge.h
@@ -9,18 +9,13 @@
 
 #import <Foundation/Foundation.h>
 #import "RCTBridgeModule.h"
-#import "OOSkinViewController.h"
 
-@class OOOoyalaPlayer;
-@class OODiscoveryOptions;
+@class OOSkinViewController;
 
 @interface OOReactBridge : NSObject<RCTBridgeModule>
 
-@property (nonatomic, weak) OOOoyalaPlayer *player;
-@property (nonatomic, weak) OOSkinViewController *skinController;
-
-+ (instancetype)getInstance;
-
 + (void)sendDeviceEventWithName:(NSString *)eventName body:(id)body;
++ (void)registerController:(OOSkinViewController *)controller;
++ (void)deregisterController:(OOSkinViewController *)controller;
 
 @end

--- a/sdk/OoyalaSkinSDK/OoyalaSkinSDK/OOSkinViewController.h
+++ b/sdk/OoyalaSkinSDK/OoyalaSkinSDK/OOSkinViewController.h
@@ -13,8 +13,9 @@
 
 @interface OOSkinViewController : UIViewController
 
-@property OODiscoveryOptions *discoveryOptions;
-@property BOOL isFullscreen;
+@property (nonatomic, readonly) OODiscoveryOptions *discoveryOptions;
+@property (nonatomic, readonly) OOOoyalaPlayer *player;
+@property (readonly) BOOL isFullscreen;
 
 - (instancetype)initWithPlayer:(OOOoyalaPlayer *)player
                         parent:(UIView *)parentView

--- a/sdk/OoyalaSkinSDK/OoyalaSkinSDK/OOSkinViewController.m
+++ b/sdk/OoyalaSkinSDK/OoyalaSkinSDK/OOSkinViewController.m
@@ -25,8 +25,6 @@
   UIView *_parentView;
 }
 
-@property (nonatomic, retain) OOOoyalaPlayer *player;
-
 @end
 
 @implementation OOSkinViewController
@@ -56,8 +54,7 @@ static NSString *kViewChangeKey = @"frame";
     [self.view addSubview:_reactView];
     [self.view addObserver:self forKeyPath:kViewChangeKey options:NSKeyValueObservingOptionNew context:&kFrameChangeContext];
 
-    [OOReactBridge getInstance].player = _player;
-    [OOReactBridge getInstance].skinController = self;
+    [OOReactBridge registerController:self];
     [_parentView addSubview:self.view];
     _isFullscreen = NO;
     _discoveryOptions = discoveryOptions;
@@ -236,6 +233,7 @@ static NSString *kViewChangeKey = @"frame";
 
 - (void)dealloc {
   [self.view removeObserver:self forKeyPath:kViewChangeKey];
+  [OOReactBridge deregisterController:self];
 }
 
 @end


### PR DESCRIPTION
basically just make RCTBridge shared cross instances and let react maintain the lifecycle. Our code no longer create bridge object, we just register skin controller to the bridge so that the data pipeline can be connected. Tested on our list sample app.
