### PR TITLE
Ignore os x and xcode 7 unnecessary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,12 @@ sdk/OoyalaSkinSDK/node_modules
 .idea/
 **/build/
 **/iOS/
+
+## Other
+*.xccheckout
+*.moved-aside
+*.xcuserstate
+*.xcscmblueprint
+
+# OS X
+.DS_Store


### PR DESCRIPTION
Ignore .DS_Store files and XCode 7 is generating files not needed. Took a bit from https://github.com/github/gitignore/blob/master/Objective-C.gitignore
