### PR TITLE
Fix UpNext variable naming based on linked skin-config

### DIFF
--- a/sdk/OoyalaSkinSDK/index.ios.js
+++ b/sdk/OoyalaSkinSDK/index.ios.js
@@ -379,7 +379,7 @@ var OoyalaSkin = React.createClass({
         config={{
           controlBar: this.props.controlBar,
           buttons: this.props.buttons.mobileContent,
-          upNextScreen: this.props.upNextScreen,
+          upNext: this.props.upNext,
           icons: this.props.icons,
           adScreen: this.props.adScreen
         }}

--- a/sdk/OoyalaSkinSDK/videoView.js
+++ b/sdk/OoyalaSkinSDK/videoView.js
@@ -182,7 +182,7 @@ var VideoView = React.createClass({
 
     return <UpNext
       config={{
-        upNext: this.props.config.upNextScreen,
+        upNext: this.props.config.upNext,
         icons: this.props.config.icons
       }}
       ad={this.props.ad}


### PR DESCRIPTION
Someone updated the skin-config submodule without going through the code very much.  Had to chagne the index.ios to use the correct props variable
