### PR TITLE
[PBA-2744] Share success pop up doesn't appear at start anymore

### DIFF
--- a/sdk/OoyalaSkinSDK/OoyalaSkinSDK.xcodeproj/project.pbxproj
+++ b/sdk/OoyalaSkinSDK/OoyalaSkinSDK.xcodeproj/project.pbxproj
@@ -331,9 +331,9 @@
 			children = (
 				2F12F36B9519079EF3B74391 /* OOFacebookSharePlugin.h */,
 				2F12F3005C36BADE48917092 /* OOFacebookSharePlugin.m */,
+				2F12F2819B6ED721603DB187 /* OOReactSocialShare.h */,
 				2F12FC6F38E21B0FC2F0C55B /* OOReactSocialShare.m */,
 				2F12FC534005E8CD971F0CDC /* OOSharePlugin.h */,
-				2F12F2819B6ED721603DB187 /* OOReactSocialShare.h */,
 				2F12FE38671D8F47CBEE8DA4 /* OOTwitterSharePlugin.h */,
 				2F12FA4EC7B6C67EFF3C5E67 /* OOTwitterSharePlugin.m */,
 			);
@@ -460,7 +460,6 @@
 		972ED84D1AE6EEEB005043DC /* OoyalaSkinSDK */ = {
 			isa = PBXGroup;
 			children = (
-				CA742B4E1BE2761D0056784E /* Utils */,
 				5E970A4D1B151431002E0CB1 /* OOClosedCaptionsViewManager.h */,
 				5E970A4E1B151431002E0CB1 /* OOClosedCaptionsViewManager.m */,
 				979B012E1B910A040032F5CF /* OOConstant.h */,
@@ -489,6 +488,7 @@
 				9769227A1B8E37F300A61ACF /* OoyalaSkinSDK.h */,
 				2F12F06F64B2FE9323AA598C /* Social */,
 				972ED84E1AE6EEEB005043DC /* Supporting Files */,
+				CA742B4E1BE2761D0056784E /* Utils */,
 			);
 			path = OoyalaSkinSDK;
 			sourceTree = "<group>";

--- a/sdk/OoyalaSkinSDK/ooyalaSkinCore.js
+++ b/sdk/OoyalaSkinSDK/ooyalaSkinCore.js
@@ -85,6 +85,11 @@ OoyalaSkinCore.prototype.onSocialButtonPress = function(socialType) {
   (results) => {Log.log(results);});
 };
 
+OoyalaSkinCore.prototype.onSocialAlertDismiss = function() {
+  this.skin.setState({alertTitle: ''});
+  this.skin.setState({alertMessage: ''});
+};
+
 OoyalaSkinCore.prototype.pauseOnOptions = function() {
   if (this.skin.state.screenType != SCREEN_TYPES.MOREOPTION_SCREEN) {
     this.previousScreenType = this.skin.state.screenType;
@@ -363,6 +368,7 @@ OoyalaSkinCore.prototype.renderSocialOptions = function() {
     <SharePanel
       socialButtons={this.skin.props.shareScreen}
       onSocialButtonPress={(socialType) => this.onSocialButtonPress(socialType)}
+      onSocialAlertDismiss={() => this.onSocialAlertDismiss()}
       width={this.skin.state.width}
       height={this.skin.state.height}
       alertTitle={this.skin.state.alertTitle}

--- a/sdk/OoyalaSkinSDK/sharePanel.js
+++ b/sdk/OoyalaSkinSDK/sharePanel.js
@@ -21,12 +21,13 @@ var SharePanel = React.createClass ({
 	propTypes: {
 		socialButtons: React.PropTypes.array,
 		onSocialButtonPress: React.PropTypes.func,
+		onSocialAlertDismiss: React.PropTypes.func,
 		width: React.PropTypes.number,
 		height: React.PropTypes.number,
 		alertTitle: React.PropTypes.string,
 		alertMessage: React.PropTypes.string,
 		localizableStrings: React.PropTypes.object,
-		locale: React.PropTypes.string
+		locale: React.PropTypes.string,
 	},
 
 	getInitialState: function() {
@@ -52,19 +53,24 @@ var SharePanel = React.createClass ({
 		this.props.onSocialButtonPress(serviceType);
 	},
 
+	onSocialAlertDismiss: function() {
+		Log.log('Ok Pressed!');
+		this.props.onSocialAlertDismiss();
+	},
+
 	render: function() {
 		var sharePanel;
 		var socialButtons = [];
 
 		var postShareSuccessAlert;
 
-		if(this.props.alertTitle != ""){
+		if(this.props.alertTitle !== ""){
 			postShareSuccessAlert = AlertIOS.alert(
 				this.props.alertTitle,
-  			this.props.alertMessage,
-  			[
-    			{text: 'Ok', onPress: () => Log.log('Ok Pressed!')},
-  			]
+				this.props.alertMessage,
+				[
+					{ text: 'Ok', onPress: this.onSocialAlertDismiss },
+				]
 			);
 		}
 


### PR DESCRIPTION
The problem was that after sending a successful message over Twitter or Facebook, we show a pop up telling that the post was successful, but when you exit the share screen to playback the video, and then return to the share screen again, the first thing you would see is the same pop up that message was successfully sent, but we haven't sent anything at this moment.
