### PR TITLE
[PBA-2802] Add JS listener to volume change event

### DIFF
--- a/sdk/OoyalaSkinSDK/OoyalaSkinSDK/OOVolumeManager.m
+++ b/sdk/OoyalaSkinSDK/OoyalaSkinSDK/OOVolumeManager.m
@@ -13,7 +13,7 @@
 #import "OOReactBridge.h"
 
 NSString *const VolumePropertyKey = @"outputVolume";
-NSString *const VolumeChangeKey = @"volumeChange";
+NSString *const VolumeChangeKey = @"volumeChanged";
 
 @implementation OOVolumeManager
 

--- a/sdk/OoyalaSkinSDK/ooyalaSkinCore.js
+++ b/sdk/OoyalaSkinSDK/ooyalaSkinCore.js
@@ -44,6 +44,7 @@ OoyalaSkinCore.prototype.mount = function(eventEmitter) {
     [ 'timeChanged',              (event) => this.onTimeChange(event) ],
     [ 'currentItemChanged',       (event) => this.onCurrentItemChange(event) ],
     [ 'frameChanged',             (event) => this.onFrameChange(event) ],
+    [ 'volumeChanged',            (event) => this.onVolumeChanged(event) ],
     [ 'playCompleted',            (event) => this.onPlayComplete(event) ],
     [ 'stateChanged',             (event) => this.onStateChange(event) ],
     [ 'discoveryResultsReceived', (event) => this.onDiscoveryResult(event) ],
@@ -263,7 +264,7 @@ OoyalaSkinCore.prototype.onPostShareAlert = function(e) {
   this.skin.setState({alertMessage: e.message});
 };
 
-OoyalaSkinCore.prototype.onVolumeChange = function(e) {
+OoyalaSkinCore.prototype.onVolumeChanged = function(e) {
   this.skin.setState({volume: e.volume});
 };
 
@@ -324,6 +325,7 @@ OoyalaSkinCore.prototype.renderVideoView = function() {
       live ={this.skin.state.live}
       width={this.skin.state.width}
       height={this.skin.state.height}
+      volume={this.skin.state.volume}
       fullscreen={this.skin.state.fullscreen}
       onPress={(value) => this.handlePress(value)}
       onScrub={(value) => this.handleScrub(value)}


### PR DESCRIPTION
I don't know why, but it when the ooyalaSkinCore.js was created, the volume listener I added was removed. I added it again and the volume icon is being shown correctly once more.

Also changed the event name to 'volumeChanged', as it resembles to the others.
