### PR TITLE
[PBA-2767] Fix timeout usage

### DIFF
--- a/sdk/OoyalaSkinSDK/discoveryPanel.js
+++ b/sdk/OoyalaSkinSDK/discoveryPanel.js
@@ -52,7 +52,7 @@ var DiscoveryPanel = React.createClass({
       showCircularStatus: false,
       currentCounterVal: 0,
       counterLimit: 0,
-      timeout: null,
+      timer: null,
     };
   },
 
@@ -78,8 +78,8 @@ var DiscoveryPanel = React.createClass({
   },
 
   clearTimer: function() {
-    if (this.state.timeout) {
-      this.clearTimeout(this.state.timeout);
+    if (this.state.timer) {
+      this.clearInterval(this.state.timer);
     }
   },
 
@@ -106,18 +106,17 @@ var DiscoveryPanel = React.createClass({
       counterLimit: time,
       showCircularStatus: true,
     });
+
+    var timer = this.setInterval(() => {
+      this.setState({currentCounterVal: this.state.currentCounterVal - 1});
+    }, 1000);
+    this.setState({timer: timer});
   },
 
-  updateTimer: function(row) {
+  checkTimer: function(row) {
     if (this.state.currentCounterVal === 0) {
       this.onRowSelected(row);
       this.clearTimer();
-    } else if (!this.state.timeout) {
-      var timeout = this.setTimeout(() => {
-        this.setState({currentCounterVal: this.state.currentCounterVal - 1});
-        this.setState({timeout: null});
-      }, 1000);
-      this.setState({timeout: timeout});
     }
   },
 
@@ -174,7 +173,7 @@ var DiscoveryPanel = React.createClass({
     var circularStatus;
     if (itemID === 0 && this.props.screenType === SCREEN_TYPES.END_SCREEN && this.state.showCircularStatus) {
       circularStatus = this.renderCircularStatus();
-      this.updateTimer(item);
+      this.checkTimer(item);
     }
 
     var thumbnail = (

--- a/sdk/OoyalaSkinSDK/discoveryPanel.js
+++ b/sdk/OoyalaSkinSDK/discoveryPanel.js
@@ -15,6 +15,7 @@ var {
   View,
   ScrollView
 } = React;
+var TimerMixin = require('react-timer-mixin');
 
 var Utils = require('./utils');
 var ResponsiveList = require('./widgets/ResponsiveList');
@@ -32,6 +33,8 @@ var widthPortrait = 375;
 var animationDuration = 1000;
 
 var DiscoveryPanel = React.createClass({
+  mixins: [TimerMixin],
+
   propTypes: {
     localizableStrings: React.PropTypes.object,
     locale: React.PropTypes.string,
@@ -49,6 +52,7 @@ var DiscoveryPanel = React.createClass({
       showCircularStatus: false,
       currentCounterVal: 0,
       counterLimit: 0,
+      timeout: null,
     };
   },
 
@@ -94,14 +98,14 @@ var DiscoveryPanel = React.createClass({
   },
 
   updateTimer: function(row) {
-    if (this.state.currentCounterVal == 0) {
+    if (this.state.currentCounterVal === 0) {
       this.onRowSelected(row);
-    } else {
-      var self = this;
-      setTimeout(function() {
-        self.setState({currentCounterVal: self.state.currentCounterVal - 1});
-        self = null;
+    } else if (!this.state.timeout) {
+      var timeout = this.setTimeout(() => {
+        this.setState({currentCounterVal: this.state.currentCounterVal - 1});
+        this.setState({timeout: null});
       }, 1000);
+      this.setState({timeout: timeout});
     }
   },
 

--- a/sdk/OoyalaSkinSDK/discoveryPanel.js
+++ b/sdk/OoyalaSkinSDK/discoveryPanel.js
@@ -73,6 +73,16 @@ var DiscoveryPanel = React.createClass({
     }
   },
 
+  componentWillUnmount: function() {
+    this.clearTimer();
+  },
+
+  clearTimer: function() {
+    if (this.state.timeout) {
+      this.clearTimeout(this.state.timeout);
+    }
+  },
+
   onRowSelected: function(row) {
   	if (this.props.onRowAction) {
   	  this.props.onRowAction({action:"click", embedCode:row.embedCode, bucketInfo:row.bucketInfo});
@@ -100,6 +110,7 @@ var DiscoveryPanel = React.createClass({
   updateTimer: function(row) {
     if (this.state.currentCounterVal === 0) {
       this.onRowSelected(row);
+      this.clearTimer();
     } else if (!this.state.timeout) {
       var timeout = this.setTimeout(() => {
         this.setState({currentCounterVal: this.state.currentCounterVal - 1});

--- a/sdk/OoyalaSkinSDK/discoveryPanel.js
+++ b/sdk/OoyalaSkinSDK/discoveryPanel.js
@@ -97,6 +97,7 @@ var DiscoveryPanel = React.createClass({
 
   onStatusPressed: function() {
     this.setState({showCircularStatus: false});
+    this.clearTimer();
   },
 
   setCounterTime: function(time) {

--- a/sdk/OoyalaSkinSDK/package.json
+++ b/sdk/OoyalaSkinSDK/package.json
@@ -19,13 +19,18 @@
       "promise",
       "source-map"
     ],
-    "moduleFileExtensions": ["js", "json", "es6"],
+    "moduleFileExtensions": [
+      "js",
+      "json",
+      "es6"
+    ],
     "collectCoverage": true
   },
   "devDependencies": {
     "jest-cli": "~0.7.0"
   },
   "dependencies": {
-    "react-native": "^0.13.2"
+    "react-native": "^0.13.2",
+    "react-timer-mixin": "^0.13.3"
   }
 }


### PR DESCRIPTION
setTimeout was being called more than once. We may need to eliminate setTimeout completely, but for now this works. I added React's recommended Timer mixin, that substitute the global setTimeout with their own, so is safer to use on React native.

One thing I don't like with this timeout implementation, is that we get a warning in the console each time the timer is updated: 'Warning: setState(...): Cannot update during an existing state transition (such as within `render`). Render methods should be a pure function of props and state.' We may need to think in another way to update the timer, as they way I'm doing it, I'm updating a var that triggers a re-render of the UI within the render function, and that shouldn't happen.
