### PR TITLE
[PBA-2878] Rollback scrubber handleTouchMove()

### DIFF
--- a/sdk/react/bottomOverlay.js
+++ b/sdk/react/bottomOverlay.js
@@ -161,7 +161,6 @@ var BottomOverlay = React.createClass({
   handleTouchMove: function(event) {
     this.setState({x:event.nativeEvent.pageX});
     this.props.onPress(BUTTON_NAMES.RESET_AUTOHIDE);
-    this.props.onScrub(this.touchPercent(event.nativeEvent.pageX));
   },
 
   handleTouchEnd: function(event) {


### PR DESCRIPTION
The PR #253 introduced an additional line of code in the handleTouchMove function
for the bottomOverlay component. I'm removing it as it is causing the bug described
in PBA-2878.

We may put it back again but considering that it breaks the UX in iOS when you try
to drag the scrub bar for the volume component, as it also drags the progress bar.
