### PR TITLE
[PBA-2837] Change Control bar UI depending on Live DVR

### DIFF
--- a/sdk/react/bottomOverlay.js
+++ b/sdk/react/bottomOverlay.js
@@ -171,9 +171,8 @@ var BottomOverlay = React.createClass({
     this.props.onPress(BUTTON_NAMES.RESET_AUTOHIDE);
   },
 
-  render: function() {
+  renderDefault: function(widthStyle) {
     var playedPercent = this.playedPercent(this.props.playhead, this.props.duration);
-    var widthStyle = {width:this.props.width, opacity:this.state.opacity};
     return (
       <Animated.View style={[styles.container, widthStyle, {"height": this.state.height}]}
         onTouchStart={(event) => this.handleTouchStart(event)}
@@ -184,7 +183,24 @@ var BottomOverlay = React.createClass({
         {this._renderProgressScrubber(this.state.touch? this.touchPercent(this.state.x) : playedPercent)}
       </Animated.View>
     );
-  }
+  },
+
+  renderLiveWithoutDVR: function(widthStyle) {
+    return (
+      <Animated.View style={[styles.container, widthStyle, {"height": this.state.height - 6}]}>
+        {this._renderControlBar()}
+      </Animated.View>
+    );
+  },
+
+  render: function() {
+    var widthStyle = {width:this.props.width, opacity:this.state.opacity};
+    if (this.props.live && !this.props.config.live.dvrEnabled) {
+      return this.renderLiveWithoutDVR(widthStyle);
+    }
+
+    return this.renderDefault(widthStyle);
+  },
 });
 
 module.exports = BottomOverlay;

--- a/sdk/react/ooyalaSkinCore.js
+++ b/sdk/react/ooyalaSkinCore.js
@@ -236,7 +236,7 @@ OoyalaSkinCore.prototype.onStateChange = function(e) {
       this.skin.setState({
         playing: true,
         loading: false,
-        initialPlay: (this.skin.state.screenType == SCREEN_TYPES.START_SCREEN) ? true : false, 
+        initialPlay: (this.skin.state.screenType == SCREEN_TYPES.START_SCREEN) ? true : false,
         screenType: SCREEN_TYPES.VIDEO_SCREEN});
       break;
     case "loading":
@@ -359,7 +359,8 @@ OoyalaSkinCore.prototype.renderVideoView = function() {
         buttons: this.skin.props.buttons.mobileContent,
         upNext: this.skin.props.upNext,
         icons: this.skin.props.icons,
-        adScreen: this.skin.props.adScreen
+        adScreen: this.skin.props.adScreen,
+        live: this.skin.props.live
       }}
       nextVideo={this.skin.state.nextVideo}
       upNextDismissed={this.skin.state.upNextDismissed}

--- a/sdk/react/videoView.js
+++ b/sdk/react/videoView.js
@@ -117,10 +117,10 @@ var VideoView = React.createClass({
         this.props.onScrub(1);
       } else {
         this.props.onPress(name);
-      } 
+      }
     } else {
       this.toggleControls();
-    } 
+    }
   },
 
   toggleControls: function() {
@@ -155,7 +155,8 @@ var VideoView = React.createClass({
       config={{
         controlBar: this.props.config.controlBar,
         buttons: this.props.config.buttons,
-        icons: this.props.config.icons
+        icons: this.props.config.icons,
+        live: this.props.config.live
       }} />);
   },
 


### PR DESCRIPTION
Thanks to Matthew, Live DVR was already implemented (commit: dd7e6e6c34f7de2eede386f7e80d60ec9f523803). I'm just toggling the UI, to show the playhead scrubber bar if DVR is enabled or it is a VOD. If DVR is disabled, the scrubber bar is not rendered. So the user doesn't have the ability to change the playhead position.

If this is accepted, I'll create another PR in skin-config, that has the option to enable/disable DVR.
