### PR TITLE
[fix-lint] fix two lint errors that come in our build

### DIFF
--- a/sdk/android/app/build.gradle
+++ b/sdk/android/app/build.gradle
@@ -17,6 +17,9 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    lintOptions {
+       warning 'InvalidPackage'
+    }
 }
 
 dependencies {

--- a/sdk/android/app/src/main/res/menu/menu_main.xml
+++ b/sdk/android/app/src/main/res/menu/menu_main.xml
@@ -3,6 +3,5 @@
       tools:context=".MainActivity">
     <item android:id="@+id/action_settings"
           android:title="@string/action_settings"
-          android:orderInCategory="100"
-          android:showAsAction="never"/>
+          android:orderInCategory="100"/>
 </menu>

--- a/sdk/android/sdk/build.gradle
+++ b/sdk/android/sdk/build.gradle
@@ -19,6 +19,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    
+    lintOptions {
+       warning 'InvalidPackage'
+    }
 }
 
 dependencies {


### PR DESCRIPTION
there is a okio package as part of react native that causes this failure:

Invalid package reference in library; not included in Android: java.nio.file. Referenced from okio.Okio.

this might not be necessary in the app, once we start compiling with the .aar
