### PR TITLE
[PBA-2546] Check url stays empty if it is empty in react

### DIFF
--- a/sdk/iOS/OoyalaSkinSDK/Social/OOActivityView.m
+++ b/sdk/iOS/OoyalaSkinSDK/Social/OOActivityView.m
@@ -28,8 +28,9 @@ RCT_EXPORT_METHOD(show:(NSDictionary *)options) {
     [items addObject:text];
   }
   
-  NSURL *url = [RCTConvert NSURL:options[@"link"]];
-  if (url) {
+  NSString *urlStr = [RCTConvert NSString:options[@"link"]];
+  NSURL *url;
+  if (urlStr.length > 0 && (url = [RCTConvert NSURL:urlStr]) != nil) {
     [items addObject:url];
   }
   

--- a/sdk/iOS/OoyalaSkinSDK/Social/OOActivityView.m
+++ b/sdk/iOS/OoyalaSkinSDK/Social/OOActivityView.m
@@ -19,7 +19,8 @@ RCT_EXPORT_MODULE();
   return dispatch_get_main_queue();
 }
 
-RCT_EXPORT_METHOD(show:(NSDictionary *)options) {
+RCT_EXPORT_METHOD(show:(NSDictionary *)options)
+{
   
   NSMutableArray *items = [NSMutableArray new];
   
@@ -28,9 +29,8 @@ RCT_EXPORT_METHOD(show:(NSDictionary *)options) {
     [items addObject:text];
   }
   
-  NSString *urlStr = [RCTConvert NSString:options[@"link"]];
-  NSURL *url;
-  if (urlStr.length > 0 && (url = [RCTConvert NSURL:urlStr]) != nil) {
+  NSURL *url = [self shareURL:options[@"link"]];
+  if (url) {
     [items addObject:url];
   }
   
@@ -75,6 +75,20 @@ RCT_EXPORT_METHOD(show:(NSDictionary *)options) {
   activityVC.popoverPresentationController.sourceRect = (CGRect) {ctrl.view.center, {1, 1}};
   
   [ctrl presentViewController:activityVC animated:YES completion:nil];
+}
+
+- (NSURL *)shareURL:(id)link
+{
+  NSString *urlStr = [RCTConvert NSString:link];
+  NSURL *url;
+  if (urlStr.length > 0 &&
+      (url = [RCTConvert NSURL:urlStr]) != nil &&
+      url.host &&
+      ([url.scheme isEqualToString:@"http"] || [url.scheme isEqualToString:@"https"])) {
+    return url;
+  }
+  
+  return nil;
 }
 
 @end


### PR DESCRIPTION
In our react code, we may send an empty link to be shared, because it isn't populated for that video content asset. In Obj-C the [RCTConvert NSURL:] was returning a non empty URL, pointing to an .app file that doesn't have to be shared at all.

This code makes sure that if react gives an empty url, it stays empty.
