### PR TITLE
[PBA-3132] Fix bug of fullscreen inactive after rotating device twice

### DIFF
--- a/sdk/iOS/OoyalaSkinSDK/OOSkinViewController.m
+++ b/sdk/iOS/OoyalaSkinSDK/OOSkinViewController.m
@@ -380,6 +380,7 @@ static NSDictionary *kSkinCofig;
       self.view.alpha = 1.f;
     } completion:^(BOOL finished) {
       [_movieFullScreenView removeFromSuperview];
+      [_movieFullScreenView setFrame:CGRectZero];
     }];
   }
   if( wasPlaying ) {

--- a/sdk/iOS/OoyalaSkinSDK/OOSkinViewController.m
+++ b/sdk/iOS/OoyalaSkinSDK/OOSkinViewController.m
@@ -351,9 +351,8 @@ static NSDictionary *kSkinCofig;
     }
     UIWindow *window = [UIApplication sharedApplication].keyWindow;
     
-    if (CGRectEqualToRect(_movieFullScreenView.frame, CGRectZero)) {
-      [_movieFullScreenView setFrame:window.bounds];
-    }
+    [_movieFullScreenView setFrame:window.bounds];
+
     [window addSubview:_movieFullScreenView];
     [_movieFullScreenView addSubview:self.view];
     [self.view setFrame:window.bounds];
@@ -380,7 +379,6 @@ static NSDictionary *kSkinCofig;
       self.view.alpha = 1.f;
     } completion:^(BOOL finished) {
       [_movieFullScreenView removeFromSuperview];
-      [_movieFullScreenView setFrame:CGRectZero];
     }];
   }
   if( wasPlaying ) {


### PR DESCRIPTION
The bug is caused by movieFullScreenView: usually it will set to current screen's bound. However, due to  the sensor inaccuracy of the device (I guess), the movieFullScreenView uses the previous landscape/portrait bound during portrait/landscape mode. By setting its bound to zero every time would force the view to reset if users tap fullscreen button; thus the problem shall not happen any more.
