### PR TITLE
[PBA-3326] iOS only - customize switch color

### DIFF
--- a/sdk/react/widgets/ToggleSwitch.js
+++ b/sdk/react/widgets/ToggleSwitch.js
@@ -17,6 +17,7 @@ var Constants = require('../constants');
 
 var styles = require('../utils').getStyles(require('./style/ToggleSwitchStyles.json'));
 
+// Tint props only work for iOS.
 var ToggleSwitch = React.createClass({
   propTypes: {
     switchOn: React.PropTypes.bool,
@@ -24,7 +25,18 @@ var ToggleSwitch = React.createClass({
     switchOnText: React.PropTypes.string,
     switchOffText: React.PropTypes.string,
     onValueChanged: React.PropTypes.func,
-    config: React.PropTypes.object
+    config: React.PropTypes.object,
+    onTintColor: React.PropTypes.string,
+    tintColor: React.PropTypes.string,
+    thumbTintColor: React.PropTypes.string,
+  },
+
+  getDefaultProps: function() {
+    return {
+      onTintColor: '#498DFC',
+      tintColor: '#DDDDDD',
+      thumbTintColor: '#FFFFFF',
+    };
   },
 
   onSwitchToggled: function() {
@@ -37,7 +49,14 @@ var ToggleSwitch = React.createClass({
     return (
         <View style={styles.container}>
           <Text style={offTextStyle}>{this.props.switchOffText}</Text>
-            <Switch style={{"width":50}} value={this.props.switchOn} onValueChange={this.onSwitchToggled} disabled={!this.props.areClosedCaptionsAvailable} />
+            <Switch
+              style={{"width":50}}
+              value={this.props.switchOn}
+              onValueChange={this.onSwitchToggled}
+              disabled={!this.props.areClosedCaptionsAvailable}
+              onTintColor={this.props.onTintColor}
+              tintColor={this.props.tintColor}
+              thumbTintColor={this.props.thumbTintColor} />
           <Text style={onTextStyle}>{this.props.switchOnText}</Text>
         </View>
     );


### PR DESCRIPTION
This only works for iOS.

Currently in Android, the only way to change the color of the switch is through the Theme and Style APIs provided in native android. I don't know if we should go this way or just state in our documentation that it is the responsibility of the developer to change the color of a switch in their Android app through a theme. (ref: https://github.com/facebook/react-native/issues/2903)
