### PR TITLE
Fix CountdownView crash for iOS7

### DIFF
--- a/sdk/iOS/OoyalaSkinSDK/Views/CountdownView.m
+++ b/sdk/iOS/OoyalaSkinSDK/Views/CountdownView.m
@@ -182,9 +182,9 @@
 
 - (void)layoutSubviews
 {
-  [super layoutSubviews];
   [self configure];
   self.circleLayer.path = [[self circlePath] CGPath];
+  [super layoutSubviews];
 }
 
 - (void)dealloc


### PR DESCRIPTION
apparently configure modifies some sort of subview constraint that causes invalidation, making device throw an exception

see http://stackoverflow.com/questions/19837097/why-am-i-getting-a-auto-layout-still-required-after-executing-layoutsubviews

see https://github.com/ooyala/ios-sample-apps/issues/96
