### PR TITLE
Fix Facebook class collision for BundleJSONConverter

### DIFF
--- a/sdk/android/ooyalaSkinSDK/src/main/java/com/ooyala/android/skin/OoyalaSkinLayoutController.java
+++ b/sdk/android/ooyalaSkinSDK/src/main/java/com/ooyala/android/skin/OoyalaSkinLayoutController.java
@@ -14,7 +14,7 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.widget.FrameLayout;
 
-import com.facebook.internal.BundleJSONConverter;
+import com.ooyala.android.skin.util.BundleJSONConverter;
 import com.facebook.react.LifecycleState;
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactRootView;

--- a/sdk/android/ooyalaSkinSDK/src/main/java/com/ooyala/android/skin/util/BundleJSONConverter.java
+++ b/sdk/android/ooyalaSkinSDK/src/main/java/com/ooyala/android/skin/util/BundleJSONConverter.java
@@ -18,7 +18,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package com.facebook.internal;
+package com.ooyala.android.skin.util;
 
 import android.os.Bundle;
 import android.util.Log;


### PR DESCRIPTION
We pulled Facebook code, but didn't change the package which causes collision with compile('com.facebook.android:facebook-android-sdk:4.+')
