### PR TITLE
[CountdownView] Support new values from skin.json

### DIFF
--- a/sdk/android/ooyalaSkinSDK/src/main/java/com/ooyala/android/skin/view/CountdownView.java
+++ b/sdk/android/ooyalaSkinSDK/src/main/java/com/ooyala/android/skin/view/CountdownView.java
@@ -29,7 +29,7 @@ public class CountdownView extends View {
     private float textSize;
     private int textColor;
     private int progress = 0;
-    private int maxTimeSec;
+    private double maxTimeSec;
     private int mainColor;
     private int secondaryColor;
     private int fillColor;
@@ -110,7 +110,7 @@ public class CountdownView extends View {
         setMeasuredDimension(widthMeasureSpec, heightMeasureSpec);
     }
 
-    public void setMaxTimeSec(int maxTimeSec) {
+    public void setMaxTimeSec(double maxTimeSec) {
         this.maxTimeSec = maxTimeSec;
         invalidate();
     }
@@ -130,10 +130,10 @@ public class CountdownView extends View {
 
     public void start() {
 
-        new CountDownTimer((maxTimeSec - progress) * 1000, 100) {
+        new CountDownTimer(((int)maxTimeSec - progress) * 1000, 100) {
             public void onTick(long millisUntilFinished) {
                 int secUntilFinished = (int) (millisUntilFinished / 1000);
-                setProgress(maxTimeSec - secUntilFinished);
+                setProgress((int) (maxTimeSec - secUntilFinished));
                 text = String.valueOf(secUntilFinished);
             }
 

--- a/sdk/android/ooyalaSkinSDK/src/main/java/com/ooyala/android/skin/view/CountdownViewManager.java
+++ b/sdk/android/ooyalaSkinSDK/src/main/java/com/ooyala/android/skin/view/CountdownViewManager.java
@@ -30,7 +30,7 @@ public class CountdownViewManager extends SimpleViewManager<CountdownView> {
         String textColor = countdown.getString("text_color");
         Integer strokeWidth = countdown.getInt("stroke_width");
         Integer textSize = countdown.getInt("text_size");
-        Integer maxTime = countdown.getInt("max_time");
+        Double maxTime = countdown.getDouble("max_time");
         Integer progress = countdown.getInt("progress");
         Boolean automatic = countdown.getBoolean("automatic");
 
@@ -46,7 +46,7 @@ public class CountdownViewManager extends SimpleViewManager<CountdownView> {
         if(automatic) {
             view.start();
         } else {
-            view.setText(String.valueOf(maxTime - progress));
+            view.setText(String.valueOf((int) (maxTime - progress)));
         }
         view.invalidate();
     }

--- a/sdk/react/panels/discoveryPanel.js
+++ b/sdk/react/panels/discoveryPanel.js
@@ -80,7 +80,7 @@ var DiscoveryPanel = React.createClass({
   componentDidMount:function () {
     // After the first render, we don't want to fire any more impressions requests
     this.setImpressionsFired(true);
-    
+
     this.state.opacity.setValue(0);
     Animated.parallel([
       Animated.timing(
@@ -195,7 +195,7 @@ var DiscoveryPanel = React.createClass({
               text_color:"#AAffffff",
               stroke_width:10,
               text_size:75,
-              max_time:10,
+              max_time:this.state.counterTime,
               progress:0,
               automatic:true}}
               data={{embedCode:item.embedCode,bucketInfo:item.bucketInfo}}/>);
@@ -208,8 +208,8 @@ var DiscoveryPanel = React.createClass({
                height: 44,
              }}
              automatic={true}
-             time={this.state.counterLimit}
-             timeLeft={this.state.counterLimit}
+             time={this.state.counterTime}
+             timeLeft={this.state.counterTime}
              radius={22}
              fillColor={'#000000'}
              strokeColor={'#ffffff'}

--- a/sdk/react/upNext.js
+++ b/sdk/react/upNext.js
@@ -18,6 +18,7 @@ var Constants = require('./constants');
 var descriptionMinWidth = 140;
 var thumbnailWidth = 175;
 var dismissButtonWidth = 10;
+var defaultCountdownVal = 10;
 
 var UpNext = React.createClass({
   propTypes: {
@@ -41,13 +42,33 @@ var UpNext = React.createClass({
   },
 
   upNextDuration: function() {
-
-    if(this.props.config.upNext.timeToShow.indexOf('%') >= 0) {
-      return (this.props.duration - parseFloat(this.props.config.upNext.timeToShow.slice(0,-1) / 100) * this.props.duration);
-    }
-    // else if we are given a number of seconds from end in which to show the upnext dialog.
-    else {
-      return parseInt(this.props.config.upNext.timeToShow);
+    // TODO: Unit test this functionality, there're still some edge cases
+    if (typeof this.props.config.upNext.timeToShow === 'string') {
+      // Support old version of percentage (e.g. "80%")
+      if (this.props.config.upNext.timeToShow.indexOf('%') >= 0) {
+        return (this.props.duration - parseFloat(this.props.config.upNext.timeToShow.slice(0,-1) / 100) * this.props.duration);
+      }
+      else if (isNaN(this.props.config.upNext.timeToShow)) {
+        // The string is not a valid number
+        return defaultCountdownVal;
+      } else {
+        // if we are given a number of seconds from end in which to show the upnext dialog.
+        return parseInt(this.props.config.upNext.timeToShow);
+      }
+    } else if (typeof this.props.config.upNext.timeToShow === 'number'){
+      if (this.props.config.upNext.timeToShow > 0.0 && this.props.config.upNext.timeToShow <= 1.0) {
+        // New percentage mode (e.g. 0.8)
+        return this.props.duration - this.props.config.upNext.timeToShow * this.props.duration;
+      } else if (this.props.config.upNext.timeToShow > 1.0) {
+        // Normal number (e.g. 15)
+        return this.props.config.upNext.timeToShow;
+      } else {
+        // 0 or negative number
+        return defaultCountdownVal;
+      }
+    } else {
+      // Not a valid string nor number, return default.
+      return defaultCountdownVal;
     }
   },
 


### PR DESCRIPTION
CountdownView now supports number values and not just strings. Some examples of what we support are:
* "10"
* "80%"
* 10
* 0.8

The skin.json still needs to be configured, the related PR is https://github.com/ooyala/skin-config/pull/162. I merged that PR already so we need to update our skin-config submodule to get these new changes, but with this PR the code will already support the new skin-config.

Some other fixes: 
* Fixed a bug for Android that didn't allow the CountdownView a percentage string value (e.g. "80%").
* Fixed a bug for Android that wasn't reading the `counterTime` value in skin.json to be used in the CountdownView in the end screen, so it was always showing a hardcoded value of `10`.