### PR TITLE
The jumping scrubber problem was caused by the playhead position gett…

### DIFF
--- a/sdk/react/bottomOverlay.js
+++ b/sdk/react/bottomOverlay.js
@@ -33,7 +33,6 @@ var leftMargin = 20;
 var progressBarHeight = 3;
 var scrubberSize = 14;
 var scrubTouchableDistance = 45;
-var scrubPositionDelta = 0.2;
 var cuePointSize = 8;
 var BottomOverlay = React.createClass({
 
@@ -104,14 +103,12 @@ var BottomOverlay = React.createClass({
   },
 
 /* 
-If the difference between the old and new scrubber positions is greater than or equal to scrubPositionDelta, it is assumed
-that the scrubber is being dragged, and therefore, cachedPlayhead is set to -1 to prevent updating the scrubber position
-until the drag is done.
+If the playhead position has changed, reset the cachedPlayhead to -1 so that it is not used when rendering the scrubber
 */
   componentWillReceiveProps: function(nextProps) {
-    if (Math.abs(this.props.playhead - nextProps.playhead) >= scrubPositionDelta) { 
+    if (this.props.playhead != nextProps.playhead) { 
        this.setState({cachedPlayhead:-1.0}); 
-    }
+    } 
   },
 
   _renderProgressBarWidth: function() {
@@ -149,7 +146,7 @@ until the drag is done.
     var playedPercent = this.playedPercent(this.props.playhead, this.props.duration);
     if (this.state.cachedPlayhead >= 0.0) {
       playedPercent = this.playedPercent(this.state.cachedPlayhead, this.props.duration);
-    }
+    } 
     return (
       <View style={styles.progressBarStyle}>
     {this._renderProgressBar(playedPercent)}

--- a/sdk/react/bottomOverlay.js
+++ b/sdk/react/bottomOverlay.js
@@ -100,6 +100,12 @@ var BottomOverlay = React.createClass({
     }
   },
 
+  componentWillReceiveProps: function(nextProps) {
+    if (Math.abs(this.props.playhead - nextProps.playhead) >= 0.2) {
+       this.setState({playhead:-1.0}); 
+    }
+  },
+
   _renderProgressBarWidth: function() {
     return this.props.width - 2 * leftMargin;
   },
@@ -133,6 +139,9 @@ var BottomOverlay = React.createClass({
       return;
     }
     var playedPercent = this.playedPercent(this.props.playhead, this.props.duration);
+    if (this.state.playhead >= 0.0) {
+      playedPercent = this.playedPercent(this.state.playhead, this.props.duration);
+    }
     return (
       <View style={styles.progressBarStyle}>
     {this._renderProgressBar(playedPercent)}
@@ -140,6 +149,7 @@ var BottomOverlay = React.createClass({
     {this._renderCuePoints(this.props.cuePoints)}
     </View>);
   },
+  
   _getCuePointLeftOffset: function(cuePoint, progressBarWidth) {
     var cuePointPercent = cuePoint / this.props.duration;
     if (cuePointPercent > 1) {
@@ -240,9 +250,9 @@ var BottomOverlay = React.createClass({
     if (this.isMounted()) {
       if (this.state.touch && this.props.onScrub) {
         this.props.onScrub(this.touchPercent(event.nativeEvent.pageX));
-      }
-      this.setState({touch:false, x:null});   
+      } 
     }
+    this.setState({touch:false, x:null, playhead: this.touchPercent(event.nativeEvent.pageX) * this.props.duration}); 
   },
 
   renderDefault: function(widthStyle) {

--- a/sdk/react/bottomOverlay.js
+++ b/sdk/react/bottomOverlay.js
@@ -104,8 +104,9 @@ var BottomOverlay = React.createClass({
   },
 
 /* 
-If the difference between the new scrubber position and the old one is greater than or equal to scrubPositionDelta,
-set the playhead to -1 to prevent setting the scrubber to the old position.
+If the difference between the old and new scrubber positions is greater than or equal to scrubPositionDelta, it is assumed
+that the scrubber is being dragged, and therefore, cachedPlayhead is set to -1 to prevent updating the scrubber position
+until the drag is done.
 */
   componentWillReceiveProps: function(nextProps) {
     if (Math.abs(this.props.playhead - nextProps.playhead) >= scrubPositionDelta) { 

--- a/sdk/react/ooyalaSkinBridgeListener.js
+++ b/sdk/react/ooyalaSkinBridgeListener.js
@@ -68,7 +68,7 @@ OoyalaSkinBridgeListener.prototype.onClosedCaptionUpdate = function(e) {
 OoyalaSkinBridgeListener.prototype.onSeekStarted = function(e) {
   Log.log( "onSeekStarted");
   this.skin.setState({
-    playhead: e.seekstart,
+    playhead: e.seekend,
     duration: e.duration,
   });
 };


### PR DESCRIPTION
The jumping scrubber problem was caused by the playhead position getting updated to its old position at the end of the drag. The fix prevents updating the playhead position during the drag and sets the playhead position correctly at the end of the drag.