### PR TITLE
[PBA-4894] Fix CachedPlayhead to only be set when actually seeking.

### DIFF
--- a/sdk/react/bottomOverlay.js
+++ b/sdk/react/bottomOverlay.js
@@ -273,9 +273,10 @@ If the playhead position has changed, reset the cachedPlayhead to -1 so that it 
     if (this.isMounted()) {
       if (this.state.touch && this.props.onScrub) {
         this.props.onScrub(this.touchPercent(event.nativeEvent.pageX));
+        this.setState({cachedPlayhead: this.touchPercent(event.nativeEvent.pageX) * this.props.duration});
       } 
     }
-    this.setState({touch:false, x:null, cachedPlayhead: this.touchPercent(event.nativeEvent.pageX) * this.props.duration}); 
+    this.setState({touch:false, x:null}); 
   },
 
   renderDefault: function(widthStyle) {


### PR DESCRIPTION
Touches are sometimes on other parts of the bottom overlay, and we set cachedPlayhead during those as well (touching duration, volume, etc)