### PR TITLE
Pba 4831

### DIFF
--- a/sdk/iOS/OoyalaSkinSDK/OOSkinPlayerObserver.m
+++ b/sdk/iOS/OoyalaSkinSDK/OOSkinPlayerObserver.m
@@ -69,6 +69,8 @@
   }
 }
 
+
+// PBA-4831 Calculate total duration from the seekable range so that seek events have a correct value for duration
 - (NSNumber *) calculateTotalDuration {
     CMTimeRange seekableRange = _player.seekableTimeRange;
     Float64 duration;

--- a/sdk/iOS/OoyalaSkinSDK/OOSkinPlayerObserver.m
+++ b/sdk/iOS/OoyalaSkinSDK/OOSkinPlayerObserver.m
@@ -69,6 +69,17 @@
   }
 }
 
+- (NSNumber *) calculateTotalDuration {
+    CMTimeRange seekableRange = _player.seekableTimeRange;
+    Float64 duration;
+    if (CMTIMERANGE_IS_INVALID(seekableRange)) {
+        duration = _player.duration;
+    } else {
+        duration = CMTimeGetSeconds(seekableRange.duration);
+    }
+    return [NSNumber numberWithFloat:duration];
+}
+
 - (void)bridgeSeekStartedNotification: (NSNotification *)notification {
   
   NSDictionary *seekInfoDictionaryObject = notification.userInfo;

--- a/sdk/iOS/OoyalaSkinSDK/OOSkinPlayerObserver.m
+++ b/sdk/iOS/OoyalaSkinSDK/OOSkinPlayerObserver.m
@@ -71,11 +71,11 @@
 
 
 // PBA-4831 Return total duration calculated from the seekable range
-- (NSNumber *) getTotalDuration {
-    CMTimeRange seekableRange = _player.seekableTimeRange;
+- (NSNumber *) getTotalDuration:(OOOoyalaPlayer *)player {
+    CMTimeRange seekableRange = player.seekableTimeRange;
     Float64 duration;
     if (CMTIMERANGE_IS_INVALID(seekableRange)) {
-        duration = _player.duration;
+        duration = player.duration;
     } else {
         duration = CMTimeGetSeconds(seekableRange.duration);
     }
@@ -83,13 +83,13 @@
 }
 
 // PBA-4831 Return adjusted playhead calculated from the seekable range
-- (NSNumber *) getAdjustedPlayhead {
-    CMTimeRange seekableRange = _player.seekableTimeRange;
+- (NSNumber *) getAdjustedPlayhead: (OOOoyalaPlayer *)player {
+    CMTimeRange seekableRange = player.seekableTimeRange;
     Float64 adjustedPlayhead;
     if (CMTIMERANGE_IS_INVALID(seekableRange)) {
-      adjustedPlayhead = _player.playheadTime;
+      adjustedPlayhead = player.playheadTime;
     } else {
-      adjustedPlayhead = _player.playheadTime - CMTimeGetSeconds(seekableRange.start);
+      adjustedPlayhead = player.playheadTime - CMTimeGetSeconds(seekableRange.start);
     }
     return [NSNumber numberWithFloat:adjustedPlayhead];
 }
@@ -100,7 +100,7 @@
   OOSeekInfo *seekInfo = seekInfoDictionaryObject[@"seekInfo"];
   NSNumber *seekStart = [NSNumber numberWithFloat:seekInfo.seekStart];
   NSNumber *seekEnd = [NSNumber numberWithFloat:seekInfo.seekEnd];
-  NSNumber *totalDuration = [self getTotalDuration];
+  NSNumber *totalDuration = [self getTotalDuration: (OOOoyalaPlayer *) _player];
   NSDictionary *eventBody = @{
                               @"seekstart":seekStart,
                               @"seekend":seekEnd,
@@ -113,7 +113,7 @@
   OOSeekInfo *seekInfo = seekInfoDictionaryObject[@"seekInfo"];
   NSNumber *seekStart = [NSNumber numberWithFloat:seekInfo.seekStart];
   NSNumber *seekEnd = [NSNumber numberWithFloat:seekInfo.seekEnd];
-  NSNumber *totalDuration = [self getTotalDuration];
+  NSNumber *totalDuration = [self getTotalDuration: (OOOoyalaPlayer *) _player];
   NSDictionary *eventBody = @{
                               @"seekstart":seekStart,
                               @"seekend":seekEnd,
@@ -144,8 +144,8 @@
 }
 
 - (void)bridgeTimeChangedNotification:(NSNotification *)notification {
-  NSNumber *playheadNumber = [self getAdjustedPlayhead];
-  NSNumber *durationNumber = [self getTotalDuration];
+  NSNumber *playheadNumber = [self getAdjustedPlayhead: (OOOoyalaPlayer *) _player];
+  NSNumber *durationNumber = [self getTotalDuration: (OOOoyalaPlayer *) _player];
   NSNumber *rateNumber = [NSNumber numberWithFloat:_player.playbackRate];
   NSMutableArray *cuePoints = [NSMutableArray arrayWithArray:[[_player getCuePointsAtSecondsForCurrentPlayer] allObjects]];
 

--- a/sdk/iOS/OoyalaSkinSDK/OOSkinPlayerObserver.m
+++ b/sdk/iOS/OoyalaSkinSDK/OOSkinPlayerObserver.m
@@ -100,7 +100,7 @@
   OOSeekInfo *seekInfo = seekInfoDictionaryObject[@"seekInfo"];
   NSNumber *seekStart = [NSNumber numberWithFloat:seekInfo.seekStart];
   NSNumber *seekEnd = [NSNumber numberWithFloat:seekInfo.seekEnd];
-  NSNumber *totalDuration = [self getTotalDuration: (OOOoyalaPlayer *) _player];
+  NSNumber *totalDuration = [self getTotalDuration: self.player];
   NSDictionary *eventBody = @{
                               @"seekstart":seekStart,
                               @"seekend":seekEnd,
@@ -113,7 +113,7 @@
   OOSeekInfo *seekInfo = seekInfoDictionaryObject[@"seekInfo"];
   NSNumber *seekStart = [NSNumber numberWithFloat:seekInfo.seekStart];
   NSNumber *seekEnd = [NSNumber numberWithFloat:seekInfo.seekEnd];
-  NSNumber *totalDuration = [self getTotalDuration: (OOOoyalaPlayer *) _player];
+  NSNumber *totalDuration = [self getTotalDuration: self.player];
   NSDictionary *eventBody = @{
                               @"seekstart":seekStart,
                               @"seekend":seekEnd,
@@ -144,8 +144,8 @@
 }
 
 - (void)bridgeTimeChangedNotification:(NSNotification *)notification {
-  NSNumber *playheadNumber = [self getAdjustedPlayhead: (OOOoyalaPlayer *) _player];
-  NSNumber *durationNumber = [self getTotalDuration: (OOOoyalaPlayer *) _player];
+  NSNumber *playheadNumber = [self getAdjustedPlayhead: self.player];
+  NSNumber *durationNumber = [self getTotalDuration: self.player];
   NSNumber *rateNumber = [NSNumber numberWithFloat:_player.playbackRate];
   NSMutableArray *cuePoints = [NSMutableArray arrayWithArray:[[_player getCuePointsAtSecondsForCurrentPlayer] allObjects]];
 

--- a/sdk/iOS/OoyalaSkinSDK/OOSkinPlayerObserver.m
+++ b/sdk/iOS/OoyalaSkinSDK/OOSkinPlayerObserver.m
@@ -86,7 +86,7 @@
   OOSeekInfo *seekInfo = seekInfoDictionaryObject[@"seekInfo"];
   NSNumber *seekStart = [NSNumber numberWithFloat:seekInfo.seekStart];
   NSNumber *seekEnd = [NSNumber numberWithFloat:seekInfo.seekEnd];
-  NSNumber *totalDuration = [NSNumber numberWithFloat:seekInfo.totalDuration];
+  NSNumber *totalDuration = [self calculateTotalDuration];
   NSDictionary *eventBody = @{
                               @"seekstart":seekStart,
                               @"seekend":seekEnd,
@@ -99,7 +99,7 @@
   OOSeekInfo *seekInfo = seekInfoDictionaryObject[@"seekInfo"];
   NSNumber *seekStart = [NSNumber numberWithFloat:seekInfo.seekStart];
   NSNumber *seekEnd = [NSNumber numberWithFloat:seekInfo.seekEnd];
-  NSNumber *totalDuration = [NSNumber numberWithFloat:seekInfo.totalDuration];
+  NSNumber *totalDuration = [self calculateTotalDuration];
   NSDictionary *eventBody = @{
                               @"seekstart":seekStart,
                               @"seekend":seekEnd,


### PR DESCRIPTION
In OOSkinPlayerObserver.m, added new methods getTotalDuration and getAdjustedPlayhead that use the seekable range to calculate and return total duration and adjusted playhead, respectively.  bridgeSeekStartedNotification and bridgeSeekCompletedNotification now call getTotalDuration to get useful duration values.  bridgeTimeChangedNotification now calls getTotalDuration and getAdjustedPlayhead.