### PR TITLE
Remove the Singleton functionality of the OOReact Bridge

### DIFF
--- a/sdk/iOS/OoyalaSkinSDK/OOReactBridge.h
+++ b/sdk/iOS/OoyalaSkinSDK/OOReactBridge.h
@@ -13,9 +13,8 @@
 @class OOSkinViewController;
 
 @interface OOReactBridge : NSObject<RCTBridgeModule>
-
-+ (void)sendDeviceEventWithName:(NSString *)eventName body:(id)body;
-+ (void)registerController:(OOSkinViewController *)controller;
-+ (void)deregisterController:(OOSkinViewController *)controller;
+- (void)sendDeviceEventWithName:(NSString *)eventName body:(id)body;
+- (void)registerController:(OOSkinViewController *)controller;
+- (void)deregisterController:(OOSkinViewController *)controller;
 
 @end

--- a/sdk/iOS/OoyalaSkinSDK/OOReactBridge.m
+++ b/sdk/iOS/OoyalaSkinSDK/OOReactBridge.m
@@ -23,8 +23,8 @@
 #import "OOConstant.h"
 
 @interface OOReactBridge()
-@property OOSkinViewController *controller;
-@property RCTBridge *rctBridge;
+@property (nonatomic, weak) OOSkinViewController *controller;
+@property (nonatomic, weak) RCTBridge *rctBridge;
 @end
 
 @implementation OOReactBridge
@@ -231,6 +231,7 @@ RCT_EXPORT_METHOD(onDiscoveryRow:(NSDictionary *)parameters) {
 
 
 - (void)dealloc {
+  LOG(@"OOReactBridge dealloc");
   [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 

--- a/sdk/iOS/OoyalaSkinSDK/OOSkinPlayerObserver.m
+++ b/sdk/iOS/OoyalaSkinSDK/OOSkinPlayerObserver.m
@@ -105,7 +105,7 @@
                               @"seekstart":seekStart,
                               @"seekend":seekEnd,
                               @"duration":totalDuration};
-  [OOReactBridge sendDeviceEventWithName:notification.name body:eventBody];
+  [self.viewController sendBridgeEventWithName:notification.name body:eventBody];
 }
 
 - (void)bridgeSeekCompletedNotification: (NSNotification *)notification {
@@ -119,7 +119,7 @@
                               @"seekend":seekEnd,
                               @"duration":totalDuration,
                               @"screenType":@"video"};
-  [OOReactBridge sendDeviceEventWithName:notification.name body:eventBody];
+  [self.viewController sendBridgeEventWithName:notification.name body:eventBody];
 }
 
 - (void)bridgeAdOverlayNotification: (NSNotification *)notification {
@@ -140,7 +140,7 @@
   [eventBody setObject:resourceUrl forKey:@"resourceUrl"];
   [eventBody setObject:clickUrl forKey:@"clickUrl"];
 
-  [OOReactBridge sendDeviceEventWithName:notification.name body:eventBody];
+  [self.viewController sendBridgeEventWithName:notification.name body:eventBody];
 }
 
 - (void)bridgeTimeChangedNotification:(NSNotification *)notification {
@@ -155,7 +155,7 @@
     @"availableClosedCaptionsLanguages":self.player.availableClosedCaptionsLanguages,
     @"cuePoints":cuePoints};
 
-  [OOReactBridge sendDeviceEventWithName:notification.name body:eventBody];
+  [self.viewController sendBridgeEventWithName:notification.name body:eventBody];
   [self notifyClosedCaptionsUpdate];
 }
 
@@ -175,7 +175,7 @@
   }
 
   NSDictionary *eventBody = @{@"text":captionText};
-  [OOReactBridge sendDeviceEventWithName:OO_CLOSED_CAPTIONS_UPDATE_EVENT body:eventBody];
+  [self.viewController sendBridgeEventWithName:OO_CLOSED_CAPTIONS_UPDATE_EVENT body:eventBody];
 }
 
 - (void) bridgeCurrentItemChangedNotification:(NSNotification *)notification {
@@ -201,7 +201,7 @@
     @"width":frameWidth,
     @"height":frameHeight,
     @"volume": volume};
-  [OOReactBridge sendDeviceEventWithName:notification.name body:eventBody];
+  [self.viewController sendBridgeEventWithName:notification.name body:eventBody];
   
   [self.viewController maybeLoadDiscovery:_player.currentItem.embedCode];
 }
@@ -214,14 +214,14 @@
   }
   NSDictionary *eventBody = @{@"state":stateString};
 
-  [OOReactBridge sendDeviceEventWithName:notification.name body:eventBody];
+  [self.viewController sendBridgeEventWithName:notification.name body:eventBody];
 }
 
 - (void) bridgeDesiredStateChangedNotification:(NSNotification *)notification {
   NSString *stateString = [OOOoyalaPlayer playerDesiredStateToString:_player.desiredState];
   NSDictionary *eventBody = @{@"desiredState":stateString};
   
-  [OOReactBridge sendDeviceEventWithName:notification.name body:eventBody];
+  [self.viewController sendBridgeEventWithName:notification.name body:eventBody];
 }
 
 - (void) bridgeErrorNotification:(NSNotification *)notification {
@@ -230,7 +230,7 @@
   NSNumber *code = [NSNumber numberWithInt:errorCode];
   NSString *detail = _player.error.description ? self.player.error.description : @"";
   NSDictionary *eventBody = @{@"code":code,@"description":detail};
-  [OOReactBridge sendDeviceEventWithName:notification.name body:eventBody];
+  [self.viewController sendBridgeEventWithName:notification.name body:eventBody];
 }
 
 - (void) bridgePlayCompletedNotification:(NSNotification *)notification {
@@ -244,7 +244,7 @@
     @"description":itemDescription,
     @"promoUrl":promoUrl,
     @"duration":durationNumber};
-  [OOReactBridge sendDeviceEventWithName:notification.name body:eventBody];
+  [self.viewController sendBridgeEventWithName:notification.name body:eventBody];
 }
 
 - (void) bridgeAdStartNotification:(NSNotification *)notification {
@@ -294,7 +294,7 @@
   if (icons) {
     [eventBody setObject:icons forKey:@"icons"];
   }
-  [OOReactBridge sendDeviceEventWithName:notification.name body:eventBody];
+  [self.viewController sendBridgeEventWithName:notification.name body:eventBody];
 
 
   if (![adInfo[@"requireAdBar"] boolValue]) {
@@ -310,7 +310,7 @@
 }
 
 - (void) bridgeAdPodStartedNotification:(NSNotification *)notification {
-  [OOReactBridge sendDeviceEventWithName:notification.name body:nil];
+  [self.viewController sendBridgeEventWithName:notification.name body:nil];
 }
 
 - (void) bridgeAdPodCompleteNotification:(NSNotification *)notification {
@@ -324,17 +324,17 @@
   NSDictionary *eventBody = @{@"duration":durationNumber,
                               @"playhead":playheadNumber};
   
-  [OOReactBridge sendDeviceEventWithName:notification.name body:eventBody];
+  [self.viewController sendBridgeEventWithName:notification.name body:eventBody];
 
   [self.viewController enableReactViewInteraction];
 }
 
 - (void) bridgePlayStartedNotification:(NSNotification *)notification {
-  [OOReactBridge sendDeviceEventWithName:notification.name body:nil];
+  [self.viewController sendBridgeEventWithName:notification.name body:nil];
 }
 
 - (void) bridgeEmbedCodeNotification:(NSNotification *)notification {
-  [OOReactBridge sendDeviceEventWithName:notification.name body:nil];
+  [self.viewController sendBridgeEventWithName:notification.name body:nil];
 }
 
 - (void)dealloc {

--- a/sdk/iOS/OoyalaSkinSDK/OOSkinViewController.h
+++ b/sdk/iOS/OoyalaSkinSDK/OOSkinViewController.h
@@ -9,6 +9,7 @@
 @class OOOoyalaPlayer;
 @class OOSkinOptions;
 @class OOClosedCaptionsStyle;
+@class OOReactBridge;
 
 /**
  * The primary class for the Skin UI
@@ -32,4 +33,6 @@ extern NSString *const OOSkinViewControllerFullscreenChangedNotification; /* Fir
                  launchOptions:(NSDictionary *)options;
 
 - (void)ccStyleChanged:(NSNotification *) notification;
+
+- (void)sendBridgeEventWithName:(NSString *)eventName body:(id)body;
 @end

--- a/sdk/iOS/OoyalaSkinSDK/OOSkinViewController.m
+++ b/sdk/iOS/OoyalaSkinSDK/OOSkinViewController.m
@@ -74,9 +74,13 @@ NSString *const OOSkinViewControllerFullscreenChangedNotification = @"fullScreen
     _isReactReady = NO;
 
     self.ooBridge = [OOReactBridge new];
+    //Passing self.ooBridge itself in the anonymous function counts as a self strong reference.
+    //I create a copy of the pointer to avoid that
+    OOReactBridge *newBridge = self.ooBridge;
+
     RCTBridge *bridge = [[RCTBridge alloc] initWithBundleURL:skinOptions.jsCodeLocation
                                               moduleProvider:^ NSArray *{
-                                                return @[self.ooBridge];
+                                                  return @[newBridge];
                                               } launchOptions:nil];
 
     _reactView = [[RCTRootView alloc] initWithBridge:bridge moduleName:@"OoyalaSkin" initialProperties:_skinConfig];

--- a/sdk/iOS/OoyalaSkinSDK/OOUpNextManager.h
+++ b/sdk/iOS/OoyalaSkinSDK/OOUpNextManager.h
@@ -6,6 +6,7 @@
 #import <Foundation/Foundation.h>
 #import <OoyalaSDK/OOOoyalaPlayer.h>
 
+@class OOReactBridge;
 
 @interface OOUpNextManager : NSObject
 
@@ -13,6 +14,7 @@
 @property (nonatomic, readonly, weak) OOOoyalaPlayer *player;
 
 - (instancetype)initWithPlayer:(OOOoyalaPlayer *)player
+                        bridge:(OOReactBridge *)bridge
                         config:(NSDictionary *)config;
 
 - (void)setNextVideo:(NSMutableArray *)nextVideo;

--- a/sdk/iOS/OoyalaSkinSDK/OOUpNextManager.m
+++ b/sdk/iOS/OoyalaSkinSDK/OOUpNextManager.m
@@ -12,6 +12,7 @@
 @interface OOUpNextManager ()
 @property(nonatomic) BOOL upNextEnabled;
 @property (nonatomic, weak) OOOoyalaPlayer *player;
+@property (nonatomic, weak) OOReactBridge *ooBridge;
 @property (nonatomic) BOOL isDismissed;
 @property (nonatomic) NSDictionary * nextVideo;
 @end
@@ -19,6 +20,7 @@
 @implementation OOUpNextManager
 
 - (instancetype)initWithPlayer:(OOOoyalaPlayer *)player
+                        bridge:(OOReactBridge *)bridge
                  config:(NSDictionary *)config {
 
   // Read the following value in from skin config
@@ -26,6 +28,8 @@
 
   // Save the player passed in with the init
   self.player = player;
+
+  self.ooBridge = bridge;
 
   //listen to currentItemChanged, on, reset state (player.currentItem.embedCode)
   [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(currentItemChangedNotification:) name:OOOoyalaPlayerCurrentItemChangedNotification object:[self player]];
@@ -42,10 +46,10 @@
 
     // After the a new video has been set, let react know that isDismissed
     // is now false.
-    [OOReactBridge sendDeviceEventWithName:@"upNextDismissed" body:@{@"upNextDismissed" : [NSNumber numberWithBool:[self isDismissed]]}];
+    [self.ooBridge sendDeviceEventWithName:@"upNextDismissed" body:@{@"upNextDismissed" : [NSNumber numberWithBool:[self isDismissed]]}];
 
     // Sets the next video to play in the upnext as specified by react.
-    [OOReactBridge sendDeviceEventWithName:@"setNextVideo" body:@{@"nextVideo" : _nextVideo}];
+    [self.ooBridge sendDeviceEventWithName:@"setNextVideo" body:@{@"nextVideo" : _nextVideo}];
   }
 }
 
@@ -75,7 +79,7 @@
   self.isDismissed = YES;
 
   // Lets react know that dismiss has been pressed.
-  [OOReactBridge sendDeviceEventWithName:@"upNextDismissed" body:@{@"upNextDismissed" : [NSNumber numberWithBool:[self isDismissed]]}];
+  [self.ooBridge sendDeviceEventWithName:@"upNextDismissed" body:@{@"upNextDismissed" : [NSNumber numberWithBool:[self isDismissed]]}];
 }
 
 - (void)dealloc {

--- a/sdk/iOS/OoyalaSkinSDK/OOVolumeManager.m
+++ b/sdk/iOS/OoyalaSkinSDK/OOVolumeManager.m
@@ -27,11 +27,6 @@ NSString *const VolumeChangeKey = @"volumeChanged";
   [[AVAudioSession sharedInstance] removeObserver:observer forKeyPath:VolumePropertyKey];
 }
 
-+ (void)sendVolumeChangeEvent:(float)volume
-{
-  [OOReactBridge sendDeviceEventWithName:VolumeChangeKey body:@{@"volume": @(volume)}];
-}
-
 + (float)getCurrentVolume
 {
   return [[AVAudioSession sharedInstance] outputVolume];


### PR DESCRIPTION
Changed ReactBridge header to be all instance methods
Use instance properties instead of static RCTBridge and SkinViewController
add ViewController Event method for non-Controller classes to send events (instead of passing around an OOReactBridge)
OOUpNextManager doesn't need any ViewController functionality, so in that case I just pass the bridge. (I can be convinced of something better here)
VolumeManager really has nothing to do with message sending, move that into the ViewController

