### PR TITLE
[PBA-4352]  Support Volume tintColor  for iOS

### DIFF
--- a/sdk/iOS/OoyalaSkinSDK/OOSkinViewController.m
+++ b/sdk/iOS/OoyalaSkinSDK/OOSkinViewController.m
@@ -228,7 +228,7 @@ NSString *const OOSkinViewControllerFullscreenChangedNotification = @"fullScreen
     NSDictionary *eventBody = @{@"width":width,@"height":height,@"fullscreen":[NSNumber numberWithBool:_isFullscreen]};
     [self sendBridgeEventWithName:(NSString *)kFrameChangeContext body:eventBody];
   } else if ([keyPath isEqualToString:outputVolumeKey]) {
-    [OOVolumeManager sendVolumeChangeEvent:[change[NSKeyValueChangeNewKey] floatValue]];
+    [self sendBridgeEventWithName:VolumeChangeKey body:@{@"volume": @([change[NSKeyValueChangeNewKey] floatValue])}];
   } else {
     [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
   }

--- a/sdk/iOS/OoyalaSkinSDK/OOVolumeManager.h
+++ b/sdk/iOS/OoyalaSkinSDK/OOVolumeManager.h
@@ -15,7 +15,6 @@ FOUNDATION_EXPORT NSString *const VolumeChangeKey;
 
 + (void)addVolumeObserver:(NSObject *)observer;
 + (void)removeVolumeObserver:(NSObject *)observer;
-+ (void)sendVolumeChangeEvent:(float)volume;
 
 + (float)getCurrentVolume;
 

--- a/sdk/iOS/OoyalaSkinSDK/Views/OOVolumeViewManager.m
+++ b/sdk/iOS/OoyalaSkinSDK/Views/OOVolumeViewManager.m
@@ -26,4 +26,5 @@ RCT_EXPORT_MODULE();
   return v;
 }
 
+RCT_REMAP_VIEW_PROPERTY(color, tintColor, UIColor)
 @end


### PR DESCRIPTION
React is **magical**! really, it just maps any input "color" prop to be a tintColor prop.

Also fixed an errant call to sendVolumeChangeEvent.  In a previous commit I removed that method implementation, had to remove it from the header as well