### PR TITLE
Properly handle observers and React views for garbage collection

### DIFF
--- a/sdk/android/skin/src/main/java/com/ooyala/android/skin/OoyalaSkinLayoutController.java
+++ b/sdk/android/skin/src/main/java/com/ooyala/android/skin/OoyalaSkinLayoutController.java
@@ -105,6 +105,8 @@ public class OoyalaSkinLayoutController extends Observable implements LayoutCont
   private String nextVideoEmbedCode = null;
 
   private ReactInstanceManager _reactInstanceManager;
+  private ReactRootView rootView;
+
   private OoyalaSkinPlayerObserver playerObserver;
   private OoyalaSkinVolumeObserver volumeObserver;
   private OoyalaSkinBridgeEventHandlerImpl eventHandler;
@@ -180,8 +182,7 @@ public class OoyalaSkinLayoutController extends Observable implements LayoutCont
     }
 
     _package = new OoyalaReactPackage(this);
-
-    ReactRootView rootView = new ReactRootView(l.getContext());
+    rootView = new ReactRootView(l.getContext());
     _reactInstanceManager = ReactInstanceManager.builder()
             .setApplication(app)
             .setBundleAssetName(skinOptions.getBundleAssetName())
@@ -511,7 +512,7 @@ public class OoyalaSkinLayoutController extends Observable implements LayoutCont
       _reactInstanceManager.onBackPressed();
     }
   }
-  @Override
+
   public void onDestroy() {
     if (_reactInstanceManager != null) {
       _reactInstanceManager.onHostDestroy();
@@ -526,6 +527,15 @@ public class OoyalaSkinLayoutController extends Observable implements LayoutCont
     if (volumeObserver != null) {
       volumeObserver.destroy();
     }
+    if (rootView != null) {
+      rootView.unmountReactApplication();
+    }
+    if (_reactInstanceManager != null) {
+      _reactInstanceManager.destroy();
+    }
+
+    DebugMode.logV(TAG, "SkinLayoutController Destroy");
+
   }
 
 

--- a/sdk/android/skin/src/main/java/com/ooyala/android/skin/OoyalaSkinLayoutController.java
+++ b/sdk/android/skin/src/main/java/com/ooyala/android/skin/OoyalaSkinLayoutController.java
@@ -516,5 +516,22 @@ public class OoyalaSkinLayoutController extends Observable implements LayoutCont
     if (_reactInstanceManager != null) {
       _reactInstanceManager.onHostDestroy();
     }
+    destroy();
+  }
+
+  /**
+   * Call this if you plan on destroying this instance of the OoyalaSkinLayoutController
+   */
+  public void destroy() {
+    if (volumeObserver != null) {
+      volumeObserver.destroy();
+    }
+  }
+
+
+  @Override
+  protected void finalize() throws Throwable {
+    DebugMode.logV(TAG, "OoyalaSkinLayoutController Finalized");
+    super.finalize();
   }
 }

--- a/sdk/android/skin/src/main/java/com/ooyala/android/skin/OoyalaSkinVolumeObserver.java
+++ b/sdk/android/skin/src/main/java/com/ooyala/android/skin/OoyalaSkinVolumeObserver.java
@@ -7,6 +7,7 @@ import android.os.Handler;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
+import com.ooyala.android.util.DebugMode;
 /**
  * Created by ukumar on 3/7/16.
  */
@@ -15,7 +16,10 @@ import com.facebook.react.bridge.WritableMap;
  * VolumeObserver listens to the volume change in the OS and fires an event to notify the react UI about the change.
  */
 class OoyalaSkinVolumeObserver {
+    final String TAG = this.getClass().toString();
 
+    protected Context context;
+    protected VolumeContentObserver volumeObserver;
     /**
      * Initialize an OoyalaSkinViewVolumeObserver
      * @param context
@@ -23,7 +27,9 @@ class OoyalaSkinVolumeObserver {
      */
     public OoyalaSkinVolumeObserver(Context context, OoyalaSkinLayoutController controller) {
         //hardware volume change observer initialization
-        VolumeContentObserver volumeObserver = new VolumeContentObserver(context, new Handler(), controller);
+        volumeObserver = new VolumeContentObserver(context, new Handler(), controller);
+        this.context = context;
+        DebugMode.logV(TAG, "Registering VolumeObserver");
         context.getContentResolver().registerContentObserver(android.provider.Settings.System.CONTENT_URI, true, volumeObserver);
     }
 
@@ -55,6 +61,13 @@ class OoyalaSkinVolumeObserver {
             WritableMap data = Arguments.createMap();
             data.putInt("volume",volume);
             controller.sendEvent("volumeChanged", data);
+        }
+    }
+
+    public void destroy() {
+        if (context != null && volumeObserver != null) {
+            DebugMode.logV(TAG, "Unregistering VolumeObserver");
+            context.getContentResolver().unregisterContentObserver(volumeObserver);
         }
     }
 }


### PR DESCRIPTION
RootView needs to be unmounted
ReactInstanceManager needs to be destroyed
Volume Observer has to be unregistered.

This will happen as long as user correctly calls onDestroy on the destroy of the activity