### PR TITLE
Fix BottomOverlay NPEs with new AccentColor functionality

### DIFF
--- a/sdk/react/ooyalaSkinPanelRenderer.js
+++ b/sdk/react/ooyalaSkinPanelRenderer.js
@@ -57,7 +57,8 @@ OoyalaSkinPanelRenderer.prototype.renderEndScreen = function() {
         endScreen: this.skin.props.endScreen,
         controlBar: this.skin.props.controlBar,
         buttons: this.skin.props.buttons.mobileContent,
-        icons: this.skin.props.icons
+        icons: this.skin.props.icons,
+        general: this.skin.props.general
       }}
       title={this.skin.state.title}
       width={this.skin.state.width}

--- a/sdk/react/panels/EndScreen.js
+++ b/sdk/react/panels/EndScreen.js
@@ -136,7 +136,8 @@ var EndScreen = React.createClass({
         controlBar: this.props.config.controlBar,
         buttons: this.props.config.buttons,
         icons: this.props.config.icons,
-        live: this.props.config.live
+        live: this.props.config.live,
+        general: this.props.config.general
       }} />);
   },
 

--- a/sdk/react/panels/adPlaybackScreen.js
+++ b/sdk/react/panels/adPlaybackScreen.js
@@ -140,7 +140,8 @@ var AdPlaybackScreen = React.createClass({
         controlBar: this.props.config.controlBar,
         buttons: this.props.config.buttons,
         icons: this.props.config.icons,
-        live: this.props.config.live
+        live: this.props.config.live,
+        general: this.props.config.general
       }} />);
   },
 


### PR DESCRIPTION
BottomOverlay requires general as part of the props, and we need to ensure any reference to BottomOverlay has general as part of config