### PR TITLE
[PBA-5493] Show Discovery on end screen correctly

### DIFF
--- a/sdk/iOS/OoyalaSkinSDK/OOUpNextManager.m
+++ b/sdk/iOS/OoyalaSkinSDK/OOUpNextManager.m
@@ -23,19 +23,21 @@
                         bridge:(OOReactBridge *)bridge
                  config:(NSDictionary *)config {
 
+  if (self = [super init]) {
   // Read the following value in from skin config
-  self.upNextEnabled = [[config objectForKey:@"showUpNext"] boolValue];
+  _upNextEnabled = [[config objectForKey:@"showUpNext"] boolValue];
 
   // Save the player passed in with the init
-  self.player = player;
+  _player = player;
 
-  self.ooBridge = bridge;
+  _ooBridge = bridge;
 
   //listen to currentItemChanged, on, reset state (player.currentItem.embedCode)
-  [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(currentItemChangedNotification:) name:OOOoyalaPlayerCurrentItemChangedNotification object:[self player]];
+  [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(currentItemChangedNotification:) name:OOOoyalaPlayerCurrentItemChangedNotification object:_player];
 
   //listen to ContentComplete, on, set Ec and play
-  [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(playCompletedNotification:) name:OOOoyalaPlayerPlayCompletedNotification object:self.player];
+  [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(playCompletedNotification:) name:OOOoyalaPlayerPlayCompletedNotification object:_player];
+  }
 
   return self;
 }

--- a/sdk/react/ooyalaSkinCore.js
+++ b/sdk/react/ooyalaSkinCore.js
@@ -72,7 +72,7 @@ OoyalaSkinCore.prototype.handleMoreOptionsButtonPress = function(buttonName) {
       break;
     case BUTTON_NAMES.CLOSED_CAPTIONS:
       this.pushToOverlayStackAndMaybePause(OVERLAY_TYPES.CLOSEDCAPTIONS_SCREEN);
-      break; 
+      break;
     case BUTTON_NAMES.SHARE:
       this.ooyalaSkinPanelRenderer.renderSocialOptions();
       break;
@@ -133,7 +133,7 @@ OoyalaSkinCore.prototype.shouldShowLandscape = function() {
 };
 
 OoyalaSkinCore.prototype.shouldShowDiscoveryEndscreen = function() {
-  return (this.skin.state.upNextDismissed == true && this.skin.props.endScreen.screenToShowOnEnd == "discovery");
+  return (!this.skin.props.upNext.showUpNext || this.skin.state.upNextDismissed) && this.skin.props.endScreen.screenToShowOnEnd === "discovery";
 };
 
 /*
@@ -153,7 +153,7 @@ OoyalaSkinCore.prototype.handleVideoTouch = function(event) {
  * Hard reset lastPressedTime, either due to button press or otherwise
  */
 OoyalaSkinCore.prototype.handleControlsTouch = function() {
-  if (this.skin.props.controlBar.autoHide === true) {  
+  if (this.skin.props.controlBar.autoHide === true) {
     Log.verbose("handleVideoTouch - Time set");
     this.skin.setState({lastPressedTime: new Date()});
   } else {

--- a/sdk/react/ooyalaSkinCore.js
+++ b/sdk/react/ooyalaSkinCore.js
@@ -133,14 +133,18 @@ OoyalaSkinCore.prototype.shouldShowLandscape = function() {
 };
 
 OoyalaSkinCore.prototype.shouldShowDiscoveryEndscreen = function() {
+  var endScreenConfig = this.skin.props.endScreen || {};
+  var upNextConfig = this.skin.props.upNext || {};
+
   // Only care if discovery on endScreen should be shown
-  if (this.skin.props.endScreen.screenToShowOnEnd !== "discovery") {
+  if (endScreenConfig.screenToShowOnEnd !== "discovery") {
     return false;
   }
 
   // player didn't show upNext so show discovery
-  // we only care about boolean values passed in the config
-  if (this.skin.props.upNext.showUpNext === false) {
+  // first we ask if showUpNext is part of the config, if not
+  // we can assume showUpNext didn't show
+  if (!upNextConfig.showUpNext || upNextConfig.showUpNext === false) {
     return true;
   }
 

--- a/sdk/react/ooyalaSkinCore.js
+++ b/sdk/react/ooyalaSkinCore.js
@@ -133,7 +133,23 @@ OoyalaSkinCore.prototype.shouldShowLandscape = function() {
 };
 
 OoyalaSkinCore.prototype.shouldShowDiscoveryEndscreen = function() {
-  return (!this.skin.props.upNext.showUpNext || this.skin.state.upNextDismissed) && this.skin.props.endScreen.screenToShowOnEnd === "discovery";
+  // Only care if discovery on endScreen should be shown
+  if (this.skin.props.endScreen.screenToShowOnEnd !== "discovery") {
+    return false;
+  }
+
+  // player didn't show upNext so show discovery
+  if (!this.skin.props.upNext.showUpNext) {
+    return true;
+  }
+
+  // player showed and closed the upNext widget
+  if (this.skin.state.upNextDismissed) {
+    return true;
+  }
+
+  // any other case
+  return false;
 };
 
 /*

--- a/sdk/react/ooyalaSkinCore.js
+++ b/sdk/react/ooyalaSkinCore.js
@@ -1,9 +1,9 @@
 /**
  * The OoyalaSkinCore handles all of the methods that perform actions based on UI actions
  */
- 'use strict';
+ "use strict";
 
-import React, { Component } from 'react';
+import React, { Component } from "react";
 import {
   ActivityIndicator,
   SliderIOS,
@@ -12,10 +12,10 @@ import {
   View,
   Image,
   TouchableHighlight,
-} from 'react-native';
+} from "react-native";
 
-var Log = require('./log');
-var Constants = require('./constants');
+var Log = require("./log");
+var Constants = require("./constants");
 var {
   BUTTON_NAMES,
   SCREEN_TYPES,
@@ -25,8 +25,8 @@ var {
   AUTOHIDE_DELAY,
   MAX_DATE_VALUE,
 } = Constants;
-var OoyalaSkinBridgeListener = require('./ooyalaSkinBridgeListener');
-var OoyalaSkinPanelRenderer = require('./ooyalaSkinPanelRenderer');
+var OoyalaSkinBridgeListener = require("./ooyalaSkinBridgeListener");
+var OoyalaSkinPanelRenderer = require("./ooyalaSkinPanelRenderer");
 
 var OoyalaSkinCore = function(ooyalaSkin, eventBridge) {
   this.skin = ooyalaSkin;
@@ -59,7 +59,7 @@ OoyalaSkinCore.prototype.onBackPressed = function() {
 };
 
 OoyalaSkinCore.prototype.handleLanguageSelection = function(e) {
-  Log.log('onLanguageSelected:'+e);
+  Log.log("onLanguageSelected:" + e);
   this.skin.setState({selectedLanguage:e});
   this.bridge.onLanguageSelected({language:e});
 };

--- a/sdk/react/ooyalaSkinCore.js
+++ b/sdk/react/ooyalaSkinCore.js
@@ -139,7 +139,8 @@ OoyalaSkinCore.prototype.shouldShowDiscoveryEndscreen = function() {
   }
 
   // player didn't show upNext so show discovery
-  if (!this.skin.props.upNext.showUpNext) {
+  // we only care about boolean values passed in the config
+  if (this.skin.props.upNext.showUpNext === false) {
     return true;
   }
 

--- a/sdk/react/panels/EndScreen.js
+++ b/sdk/react/panels/EndScreen.js
@@ -1,22 +1,22 @@
-import React, { Component } from 'react';
+import React, { Component } from "react";
 import {
   StyleSheet,
   Text,
   View,
   Image,
   TouchableHighlight
-} from 'react-native';
+} from "react-native";
 
-var Utils = require('../utils');
+var Utils = require("../utils");
 
-var styles = Utils.getStyles(require('./style/endScreenStyles.json'));
-var ProgressBar = require('../progressBar');
-var ControlBar = require('../controlBar');
-var WaterMark = require('../waterMark');
-var InfoPanel = require('../infoPanel');
-var BottomOverlay = require('../bottomOverlay');
-var Log = require('../log');
-var Constants = require('../constants');
+var styles = Utils.getStyles(require("./style/endScreenStyles.json"));
+var ProgressBar = require("../progressBar");
+var ControlBar = require("../controlBar");
+var WaterMark = require("../waterMark");
+var InfoPanel = require("../infoPanel");
+var BottomOverlay = require("../bottomOverlay");
+var Log = require("../log");
+var Constants = require("../constants");
 
 var {
   BUTTON_NAMES,
@@ -58,7 +58,7 @@ var EndScreen = React.createClass({
     Log.verbose("VideoView Handle Press: " + name);
     this.setState({lastPressedTime: new Date().getTime()});
     if (this.state.showControls) {
-      if (name == "LIVE") {
+      if (name === "LIVE") {
         this.props.onScrub(1);
       } else {
         this.props.onPress(name);
@@ -70,14 +70,13 @@ var EndScreen = React.createClass({
 
   _renderDefaultScreen: function(progressBar, controlBar) {
     var endScreenConfig = this.props.config.endScreen || {};
-    var fullscreenPromoImage = endScreenConfig === 'default';
     var replaybuttonLocation = styles.replaybuttonCenter;
     var replaybutton;
     if(endScreenConfig.showReplayButton) {
       var fontFamilyStyle = {fontFamily: this.props.config.icons.replay.fontFamilyName};
       replaybutton = (
         <TouchableHighlight
-          onPress={(name) => this.handleClick('PlayPause')}
+          onPress={(name) => this.handleClick("PlayPause")}
           underlayColor="transparent"
           activeOpacity={0.5}>
           <Text style={[styles.replaybutton, fontFamilyStyle]}>{this.props.config.icons.replay.fontString}</Text>
@@ -95,7 +94,7 @@ var EndScreen = React.createClass({
         style={styles.fullscreenContainer}>
         <Image
         source={{uri: this.props.promoUrl}}
-        style={[styles.fullscreenContainer,{position:'absolute', top:0, left:0, width:this.props.width, height: this.props.height}]}
+        style={[styles.fullscreenContainer,{position:"absolute", top:0, left:0, width:this.props.width, height: this.props.height}]}
         resizeMode={Image.resizeMode.contain}>
         </Image>
         {infoPanel}

--- a/sdk/react/panels/EndScreen.js
+++ b/sdk/react/panels/EndScreen.js
@@ -69,10 +69,11 @@ var EndScreen = React.createClass({
   },
 
   _renderDefaultScreen: function(progressBar, controlBar) {
-    var fullscreenPromoImage = (this.props.config.endScreen.mode == 'default');
+    var endScreenConfig = this.props.config.endScreen || {};
+    var fullscreenPromoImage = endScreenConfig === 'default';
     var replaybuttonLocation = styles.replaybuttonCenter;
     var replaybutton;
-    if(this.props.config.endScreen.showReplayButton) {
+    if(endScreenConfig.showReplayButton) {
       var fontFamilyStyle = {fontFamily: this.props.config.icons.replay.fontFamilyName};
       replaybutton = (
         <TouchableHighlight
@@ -84,8 +85,8 @@ var EndScreen = React.createClass({
       );
     }
 
-    var title = this.props.config.endScreen.showTitle ? this.props.title : null;
-    var description = this.props.config.endScreen.showDescription ? this.props.description : null;
+    var title = endScreenConfig.showTitle ? this.props.title : null;
+    var description = endScreenConfig.showDescription ? this.props.description : null;
     var infoPanel =
       (<InfoPanel title={title} description={description} />);
 

--- a/sdk/react/upNext.js
+++ b/sdk/react/upNext.js
@@ -1,19 +1,19 @@
-import React, { Component } from 'react';
+import React, { Component } from "react";
 import {
   StyleSheet,
   Text,
   View,
   Image,
   TouchableHighlight,
-} from 'react-native';
+} from "react-native";
 
-var Utils = require('./utils');
+var Utils = require("./utils");
 
-var styles = Utils.getStyles(require('./style/upNext.json'));
-var CountdownView = require('./widgets/countdownTimer');
-var CountdownViewAndroid = require('./widgets/countdownTimerAndroid');
-var ResponsiveDesignManager = require('./responsiveDesignManager');
-var Constants = require('./constants');
+var styles = Utils.getStyles(require("./style/upNext.json"));
+var CountdownView = require("./widgets/countdownTimer");
+var CountdownViewAndroid = require("./widgets/countdownTimerAndroid");
+var ResponsiveDesignManager = require("./responsiveDesignManager");
+var Constants = require("./constants");
 
 var descriptionMinWidth = 140;
 var thumbnailWidth = 175;
@@ -44,9 +44,9 @@ var UpNext = React.createClass({
   upNextDuration: function() {
     var upNextConfig = this.props.config.upNext || {};
     // TODO: Unit test this functionality, there're still some edge cases
-    if (typeof upNextConfig.timeToShow === 'string') {
+    if (typeof upNextConfig.timeToShow === "string") {
       // Support old version of percentage (e.g. "80%")
-      if (upNextConfig.timeToShow.indexOf('%') >= 0) {
+      if (upNextConfig.timeToShow.indexOf("%") >= 0) {
         return (this.props.duration - parseFloat(upNextConfig.timeToShow.slice(0,-1) / 100) * this.props.duration);
       }
       else if (isNaN(upNextConfig.timeToShow)) {
@@ -56,7 +56,7 @@ var UpNext = React.createClass({
         // if we are given a number of seconds from end in which to show the upnext dialog.
         return parseInt(upNextConfig.timeToShow);
       }
-    } else if (typeof upNextConfig.timeToShow === 'number'){
+    } else if (typeof upNextConfig.timeToShow === "number"){
       if (upNextConfig.timeToShow > 0.0 && upNextConfig.timeToShow <= 1.0) {
         // New percentage mode (e.g. 0.8)
         return this.props.duration - upNextConfig.timeToShow * this.props.duration;
@@ -80,7 +80,7 @@ var UpNext = React.createClass({
   _renderDismissButton: function() {
     return (<TouchableHighlight
       onPress={this.dismissUpNext}
-      underlayColor='transparent'
+      underlayColor="transparent"
       style={styles.dismissButtonContainer}>
       <Text style={[
         styles.dismissButton,

--- a/sdk/react/upNext.js
+++ b/sdk/react/upNext.js
@@ -115,7 +115,7 @@ var UpNext = React.createClass({
 
 
   render: function() {
-    if(this.isWithinShowUpNextBounds() && !this.props.upNextDismissed && this.props.config.upNext.showUpNext && !this.props.ad && this.props.nextVideo != null) {
+    if(this.isWithinShowUpNextBounds() && !this.props.upNextDismissed && this.props.config.upNext.showUpNext === true && !this.props.ad && this.props.nextVideo != null) {
       var countdown = this.renderCountdownTimer();
       var upNextImage = (
         <Image

--- a/sdk/react/upNext.js
+++ b/sdk/react/upNext.js
@@ -42,26 +42,27 @@ var UpNext = React.createClass({
   },
 
   upNextDuration: function() {
+    var upNextConfig = this.props.config.upNext || {};
     // TODO: Unit test this functionality, there're still some edge cases
-    if (typeof this.props.config.upNext.timeToShow === 'string') {
+    if (typeof upNextConfig.timeToShow === 'string') {
       // Support old version of percentage (e.g. "80%")
-      if (this.props.config.upNext.timeToShow.indexOf('%') >= 0) {
-        return (this.props.duration - parseFloat(this.props.config.upNext.timeToShow.slice(0,-1) / 100) * this.props.duration);
+      if (upNextConfig.timeToShow.indexOf('%') >= 0) {
+        return (this.props.duration - parseFloat(upNextConfig.timeToShow.slice(0,-1) / 100) * this.props.duration);
       }
-      else if (isNaN(this.props.config.upNext.timeToShow)) {
+      else if (isNaN(upNextConfig.timeToShow)) {
         // The string is not a valid number
         return defaultCountdownVal;
       } else {
         // if we are given a number of seconds from end in which to show the upnext dialog.
-        return parseInt(this.props.config.upNext.timeToShow);
+        return parseInt(upNextConfig.timeToShow);
       }
-    } else if (typeof this.props.config.upNext.timeToShow === 'number'){
-      if (this.props.config.upNext.timeToShow > 0.0 && this.props.config.upNext.timeToShow <= 1.0) {
+    } else if (typeof upNextConfig.timeToShow === 'number'){
+      if (upNextConfig.timeToShow > 0.0 && upNextConfig.timeToShow <= 1.0) {
         // New percentage mode (e.g. 0.8)
-        return this.props.duration - this.props.config.upNext.timeToShow * this.props.duration;
-      } else if (this.props.config.upNext.timeToShow > 1.0) {
+        return this.props.duration - upNextConfig.timeToShow * this.props.duration;
+      } else if (upNextConfig.timeToShow > 1.0) {
         // Normal number (e.g. 15)
-        return this.props.config.upNext.timeToShow;
+        return upNextConfig.timeToShow;
       } else {
         // 0 or negative number
         return defaultCountdownVal;
@@ -115,7 +116,8 @@ var UpNext = React.createClass({
 
 
   render: function() {
-    if(this.isWithinShowUpNextBounds() && !this.props.upNextDismissed && this.props.config.upNext.showUpNext === true && !this.props.ad && this.props.nextVideo != null) {
+    var upNextConfig = this.props.config.upNext || {};
+    if(this.isWithinShowUpNextBounds() && !this.props.upNextDismissed && upNextConfig.showUpNext === true && !this.props.ad && this.props.nextVideo != null) {
       var countdown = this.renderCountdownTimer();
       var upNextImage = (
         <Image


### PR DESCRIPTION
We weren’t showing the discovery on the end screen with showUpNext = false and screenToShowOnEnd = “discovery”. This was a bug since we would only show discovery on end screen if we dismissed the upNext widget previously. Added a logic operation bypassing the upNextDismissed question if the showUpNext button was set to false, this way we would only care about screenToShowOnEnd.

I wanted to add testing to this change but I found out that with our current dependencies versions testing is broken. We will have to fix it first and then we should add more testing to our react native code to find this kind of errors.