### PR TITLE
PBA-5502 Issues with Closed Captions

### DIFF
--- a/sdk/react/languageSelectionPreview.js
+++ b/sdk/react/languageSelectionPreview.js
@@ -41,7 +41,7 @@ var LanguageSelectionPreview = React.createClass({
     return (
       <Animated.View style={styles.previewPanel}>
       <View style={styles.splitter} />
-      <View style={styles.selectionPreviewtextContainer}>
+      <View style={styles.previewTextContainer}>
         <Text style={styles.buttonText}>{Utils.localizedString(this.props.selectedLanguage, 'CLOSED CAPTION PREVIEW', this.props.config.localizableStrings)}</Text>
         <Text style={styles.buttonText}>{Utils.localizedString(this.props.selectedLanguage, 'Sample Text', this.props.config.localizableStrings)}</Text>
       </View>

--- a/sdk/react/languageSelectionPreview.js
+++ b/sdk/react/languageSelectionPreview.js
@@ -34,15 +34,17 @@ var LanguageSelectionPreview = React.createClass({
       toValue: this.props.isVisible ? UI_SIZES.CC_PREVIEW_HEIGHT : 0,
       duration: 300,
       delay: 0
-    }).start(); 
+    }).start();
   },
 
   render() {
     return (
       <Animated.View style={styles.previewPanel}>
       <View style={styles.splitter} />
+      <View style={styles.selectionPreviewtextContainer}>
         <Text style={styles.buttonText}>{Utils.localizedString(this.props.selectedLanguage, 'CLOSED CAPTION PREVIEW', this.props.config.localizableStrings)}</Text>
         <Text style={styles.buttonText}>{Utils.localizedString(this.props.selectedLanguage, 'Sample Text', this.props.config.localizableStrings)}</Text>
+      </View>
       </Animated.View>
     );
   }

--- a/sdk/react/panels/languageSelectionPanel.js
+++ b/sdk/react/panels/languageSelectionPanel.js
@@ -8,6 +8,7 @@ import React, { Component } from 'react';
 import {
   Animated,
   ListView,
+  ScrollView,
   StyleSheet,
   SwitchIOS,
   Text,
@@ -84,12 +85,45 @@ var LanguageSelectionPanel = React.createClass({
   onTouchEnd: function(event) {
     // ignore.
   },
-  renderHeader: function() {
+  renderHeader: function(hasCC) {
     var title = Utils.localizedString(this.props.config.locale, "CC Options", this.props.config.localizableStrings);
-    var panelIcon = this.props.config.icons.cc.fontString;
+    var switchOnText = Utils.localizedString(this.props.config.locale, "On", this.props.config.localizableStrings);
+    var switchOffText = Utils.localizedString(this.props.config.locale, "Off", this.props.config.localizableStrings);
+    var panelIcon =  this.props.config.icons.cc.fontString;
+
+    var minimumWidthPanelIcon = 320;
+    var mediumWidthSwitchText = 360;
+    var fullWidthPanelIcon = 380;
+
+    var width = this.props.width
+
+    // ToggleSwitch without text + panelIcon + dismiss button
+    if (width < minimumWidthPanelIcon) {
+      title = "";
+      switchOnText = "";
+      switchOffText = "";
+    }
+    // ToggleSwitch without text + title + dismiss button
+    else if (width < mediumWidthSwitchText) {
+      switchOnText = "";
+      switchOffText = "";
+      panelIcon = "";
+    }
+    // ToggleSwitch with text + title + dismiss button
+    else if (width < fullWidthPanelIcon) {
+      panelIcon = "";
+    }
 
     return (
     <View style={panelStyles.panelTitleView}>
+      <ToggleSwitch
+        switchOn={hasCC}
+        areClosedCaptionsAvailable={this.props.languages.length > 0}
+        onValueChanged={(value)=>this.onSwitchToggled(value)}
+        switchOnText={switchOnText}
+        switchOffText={switchOffText}
+        config={this.props.config}>
+      </ToggleSwitch>
       <Text style={[panelStyles.panelTitleText]}>
       {title}
       </Text>
@@ -97,9 +131,12 @@ var LanguageSelectionPanel = React.createClass({
       <View style={panelStyles.headerFlexibleSpace}></View>
       <TouchableHighlight
         accessible={true} accessibilityLabel={BUTTON_NAMES.DISMISS} accessibilityComponentType="button"
-        style = {[panelStyles.dismissButton]}
+        style = {[panelStyles.dismissButton, {"paddingTop": 10, "paddingBottom": 0}]}
         onPress={this.onDismissPress}>
-        <Text style={panelStyles.dismissIcon}>{this.props.config.icons.dismiss.fontString}</Text>
+        <Text
+          style={[panelStyles.dismissIcon, {"paddingBottom": 0}]}>
+          {this.props.config.icons.dismiss.fontString}
+        </Text>
       </TouchableHighlight>
     </View>);
   },
@@ -117,7 +154,7 @@ var LanguageSelectionPanel = React.createClass({
     var animationStyle = {opacity:this.state.opacity};
 
     if (this.props.selectedLanguage) {
-      var previewText = 
+      var previewText =
         ( <PreviewWidget
             isVisible={hasCC}
             config={this.props.config}
@@ -125,28 +162,22 @@ var LanguageSelectionPanel = React.createClass({
           </PreviewWidget>
         );
     }
-  
+
     return (
       <Animated.View style={[styles.panelContainer, panelStyles.panel, animationStyle]}>
-        {this.renderHeader()}
-        <ToggleSwitch
-          switchOn={hasCC}
-          areClosedCaptionsAvailable={this.props.languages.length > 0}
-          onValueChanged={(value)=>this.onSwitchToggled(value)}
-          switchOnText={Utils.localizedString(this.props.config.locale, "On", this.props.config.localizableStrings)}
-          switchOffText={Utils.localizedString(this.props.config.locale, "Off", this.props.config.localizableStrings)}
-          config={this.props.config}>
-        </ToggleSwitch>
-        <ResponsiveList
-          horizontal={renderHorizontal}
-          data={this.props.languages}
-          itemRender={this.renderItem}
-          width={this.props.width}
-          height={itemPanelHeight}
-          itemWidth={160}
-          itemHeight={88}>
-        </ResponsiveList>
-        {previewText}
+        <ScrollView>
+          {this.renderHeader(hasCC)}
+          <ResponsiveList
+            horizontal={renderHorizontal}
+            data={this.props.languages}
+            itemRender={this.renderItem}
+            width={this.props.width}
+            height={itemPanelHeight}
+            itemWidth={160}
+            itemHeight={88}>
+          </ResponsiveList>
+          {previewText}
+        </ScrollView>
       </Animated.View>
     );
   },

--- a/sdk/react/panels/languageSelectionPanel.js
+++ b/sdk/react/panels/languageSelectionPanel.js
@@ -95,13 +95,17 @@ var LanguageSelectionPanel = React.createClass({
     var mediumWidthSwitchText = 360;
     var fullWidthPanelIcon = 380;
 
-    var width = this.props.width
+    var width = this.props.width;
 
     // ToggleSwitch without text + panelIcon + dismiss button
     if (width < minimumWidthPanelIcon) {
       title = "";
       switchOnText = "";
       switchOffText = "";
+    }
+    // ToggleSwitch with text + panelIcon + dismiss button
+    else if (title.length > 10 && width < fullWidthPanelIcon) {
+      title = "";
     }
     // ToggleSwitch without text + title + dismiss button
     else if (width < mediumWidthSwitchText) {
@@ -165,8 +169,8 @@ var LanguageSelectionPanel = React.createClass({
 
     return (
       <Animated.View style={[styles.panelContainer, panelStyles.panel, animationStyle]}>
+        {this.renderHeader(hasCC)}
         <ScrollView>
-          {this.renderHeader(hasCC)}
           <ResponsiveList
             horizontal={renderHorizontal}
             data={this.props.languages}

--- a/sdk/react/panels/style/languageSelectionPanelStyles.json
+++ b/sdk/react/panels/style/languageSelectionPanelStyles.json
@@ -55,7 +55,7 @@
     "alignSelf": "stretch",
     "backgroundColor": "#585858"
   },
-  "selectionPreviewtextContainer": {
+  "previewTextContainer": {
     "alignItems":"flex-start",
     "margin": 5
   },

--- a/sdk/react/panels/style/languageSelectionPanelStyles.json
+++ b/sdk/react/panels/style/languageSelectionPanelStyles.json
@@ -42,7 +42,7 @@
     "alignItems":"center",
     "backgroundColor": "transparent"
   },
-  
+
   "buttonText": {
     "textAlign": "center",
     "color": "white",
@@ -54,6 +54,10 @@
     "height": 1,
     "alignSelf": "stretch",
     "backgroundColor": "#585858"
+  },
+  "selectionPreviewtextContainer": {
+    "alignItems":"flex-start",
+    "margin": 5
   },
   "previewPanel": {
     "alignItems":"flex-start",

--- a/sdk/react/panels/style/panelStyles.json
+++ b/sdk/react/panels/style/panelStyles.json
@@ -20,8 +20,8 @@
     "padding":20,
   },
   "dismissOverlay": {
-    "position":"absolute", 
-    "left": 10, 
+    "position":"absolute",
+    "left": 10,
     "top": 10
   },
   "dismissIcon": {
@@ -41,10 +41,9 @@
     "color": "white",
   },
   "closedCaptionsContainer": {
-    "flexDirection":"row", 
-    "backgroundColor":"transparent", 
-    "alignItems":"center", 
-    "justifyContent":"center"
+    "backgroundColor":"transparent",
+    "alignItems":"center",
+    "justifyContent":"center",
   },
   "closedCaptions": {
     "alignSelf":"center",
@@ -52,7 +51,7 @@
     "padding": 2,
     "margin":2,
     "fontWeight": "bold",
-    "fontSize": 20,
+    "fontSize": 16,
     "fontFamily": "Helvetica",
     "color": "white",
     "backgroundColor": "rgba(0, 0, 0, 0.7)",

--- a/sdk/react/panels/videoView.js
+++ b/sdk/react/panels/videoView.js
@@ -163,26 +163,48 @@ var VideoView = React.createClass({
       </View>);
   },
 
-  _renderClosedCaptions: function() {
-    var {height, width} = Dimensions.get('window');
-    if (height < width) width = height; // We just want the smaller of the two values, which represents the portrait device width
+  _renderBottom: function() {
+    var VideoWaterMarkSize = ResponsiveDesignManager.makeResponsiveMultiplier(UI_SIZES.VIDEOWATERMARK, UI_SIZES.VIDEOWATERMARK);
+    var waterMarkName;
+    if(this.props.platform == Constants.PLATFORMS.ANDROID) {
+      waterMarkName = this.props.config.general.watermark.imageResource.androidResource;
+    }
+    if(this.props.platform == Constants.PLATFORMS.IOS) {
+      waterMarkName = this.props.config.general.watermark.imageResource.iosResource;
+    }
 
-    var scalingFactor = this.props.width/width;
-    var ccStyle = {fontSize: this.props.captionStyles.textSize * scalingFactor, color:this.props.captionStyles.textColor,fontFamily:this.props.captionStyles.fontName,
+    if (waterMarkName) {
+      var watermark = this._renderVideoWaterMark(waterMarkName, VideoWaterMarkSize);
+    }
+
+    return (
+      <View
+        style={{flexDirection:"row", justifyContent:"center", alignItems: "flex-end"}}>
+        {this._renderClosedCaptions(waterMarkName, VideoWaterMarkSize)}
+        {watermark}
+      </View>);
+  },
+
+  _renderClosedCaptions: function(waterMarkName, VideoWaterMarkSize) {
+    var containerPadding = 5;
+    var captionWidth = this.props.width - (containerPadding * 4);
+    if (waterMarkName) {
+      captionWidth = captionWidth - VideoWaterMarkSize;
+    }
+
+    var ccStyle = {color:this.props.captionStyles.textColor,fontFamily:this.props.captionStyles.fontName,
       backgroundColor:this.props.captionStyles.textBackgroundColor};
     if (this.props.caption) {
       return (
         <View
-          style={panelStyles.closedCaptionsContainer}
+          style={[panelStyles.closedCaptionsContainer, {padding: containerPadding, width: captionWidth}]}
           onTouchEnd={(event) => this.props.handlers.handleVideoTouch(event)}>
-          <View style={[panelStyles.closedCaptionsFlexibleSpace]}></View>
           <View
             style={[{backgroundColor:this.props.captionStyles.backgroundColor}]}>
-          <Text style={[panelStyles.closedCaptions, ccStyle]}>
-            {this.props.caption}
-          </Text>
+            <Text style={[panelStyles.closedCaptions, ccStyle]}>
+              {this.props.caption}
+            </Text>
           </View>
-          <View style={[panelStyles.closedCaptionsFlexibleSpace]}></View>
         </View>
         );
     }
@@ -239,22 +261,17 @@ var VideoView = React.createClass({
         </VideoViewPlayPause>);
   },
 
-  _renderVideoWaterMark: function() {
-    var VideoWaterMarkSize = ResponsiveDesignManager.makeResponsiveMultiplier(UI_SIZES.VIDEOWATERMARK, UI_SIZES.VIDEOWATERMARK);
-    var waterMarkName;
-    if(this.props.platform == Constants.PLATFORMS.ANDROID) {
-      waterMarkName = this.props.config.general.watermark.imageResource.androidResource;
-    }
-    if(this.props.platform == Constants.PLATFORMS.IOS) {
-      waterMarkName = this.props.config.general.watermark.imageResource.iosResource;
-    }
+  _renderVideoWaterMark: function(waterMarkName, VideoWaterMarkSize) {
     if (waterMarkName) {
       return (
-        <VideoWaterMark
-          buttonWidth={VideoWaterMarkSize}
-          buttonHeight={VideoWaterMarkSize}
-          waterMarkName={waterMarkName}/>
-          );
+        <View
+            style={{flex:1, justifyContent:"flex-end", alignItems:"flex-end"}}>
+            <VideoWaterMark
+              buttonWidth={VideoWaterMarkSize}
+              buttonHeight={VideoWaterMarkSize}
+              waterMarkName={waterMarkName}/>
+        </View>
+      );
     }
   },
 
@@ -316,7 +333,7 @@ var VideoView = React.createClass({
       );
     }
   },
-  
+
   handleScrub: function(value) {
     this.props.handlers.onScrub(value);
   },
@@ -341,8 +358,7 @@ var VideoView = React.createClass({
       <View
         style={styles.container}>
         {this._renderPlaceholder()}
-        {this._renderClosedCaptions()}
-        {this._renderVideoWaterMark()}
+        {this._renderBottom()}
         {this._renderAdOverlay()}
         {this._renderPlayPause(shouldShowControls)}
         {this._renderUpNext()}


### PR DESCRIPTION
- Wrap closed captions to the next line.
- Do not scale closed captions text size when rotating the device, instead
  use a fixed 16 size.
- Place the closed captions at the same level as the watermark, and extend
  the closed captions to the full width if there is no watermark.
- Allow the closed caption menu to resize according to the player width,
  use a ScrollBack as a fallback if the height is not enough to show all
  the buttons.