### PR TITLE
[PLAYER-1357] iOS UI issues when accessibility is enabled

### DIFF
--- a/sdk/iOS/OoyalaSkinSDK/OOSkinViewController.m
+++ b/sdk/iOS/OoyalaSkinSDK/OOSkinViewController.m
@@ -268,6 +268,8 @@ NSString *const OOSkinViewControllerFullscreenChangedNotification = @"fullScreen
     [_movieFullScreenView addSubview:self.view];
     [self.view setFrame:window.bounds];
     self.view.alpha = 0.0f;
+
+    [self.inlineViewController dismissViewControllerAnimated:NO completion:nil];
     
     [UIView animateWithDuration:FULLSCREEN_ANIMATION_DURATION delay:0.0 options:UIViewAnimationOptionCurveLinear animations:^{
       _movieFullScreenView.alpha = 1.f;

--- a/sdk/react/panels/videoView.js
+++ b/sdk/react/panels/videoView.js
@@ -158,6 +158,7 @@ var VideoView = React.createClass({
   _renderPlaceholder: function() {
     return (
       <View
+        accessible={true}
         style={styles.placeholder}
         onTouchEnd={(event) => this.props.handlers.handleVideoTouch(event)}>
       </View>);
@@ -356,6 +357,7 @@ var VideoView = React.createClass({
 
     return (
       <View
+        accessible={false}
         style={styles.container}>
         {this._renderPlaceholder()}
         {this._renderBottom()}


### PR DESCRIPTION
- Avoid videoView superview to group its children into a single
  selectable component.
- Dismiss the controller presented modally to pass user touches
  to subviews.