### PR TITLE
[Accessibility] Add Accessibility state modules

### DIFF
--- a/sdk/android/skin/src/main/java/com/ooyala/android/skin/OoyalaReactPackage.java
+++ b/sdk/android/skin/src/main/java/com/ooyala/android/skin/OoyalaReactPackage.java
@@ -8,6 +8,7 @@ import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.shell.MainReactPackage;
 import com.facebook.react.uimanager.ViewManager;
+import com.ooyala.android.skin.accessibility.AccessibilityInfoModule;
 import com.ooyala.android.skin.view.ClosedCaptionsViewManager;
 import com.ooyala.android.skin.view.CountdownViewManager;
 import com.ooyala.android.skin.view.VolumeViewManager;
@@ -33,6 +34,15 @@ class OoyalaReactPackage extends MainReactPackage {
   public List<ModuleSpec> getNativeModules(final ReactApplicationContext context) {
     List<ModuleSpec> list =  new ArrayList<>();
     list.addAll(super.getNativeModules(context));
+
+    //TODO: remove AccessibilityInfoModule when updating to latest version of react native
+    list.add(new ModuleSpec(AccessibilityInfoModule.class, new Provider<NativeModule>() {
+      @Override
+      public NativeModule get() {
+        return new AccessibilityInfoModule(context);
+      }
+    }));
+
     _bridge = new OoyalaReactBridge(context, _layoutcontroller.getBridgeEventHandler());
     list.add(new ModuleSpec(OoyalaReactBridge.class, new Provider() {
       public NativeModule get() {

--- a/sdk/android/skin/src/main/java/com/ooyala/android/skin/accessibility/AccessibilityInfoModule.java
+++ b/sdk/android/skin/src/main/java/com/ooyala/android/skin/accessibility/AccessibilityInfoModule.java
@@ -1,0 +1,99 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+//TODO: remove this file when updating to latest version of react native
+
+package com.ooyala.android.skin.accessibility;
+
+import javax.annotation.Nullable;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.os.Build;
+import android.view.accessibility.AccessibilityManager;
+
+import com.facebook.react.bridge.Callback;
+import com.facebook.react.bridge.LifecycleEventListener;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.module.annotations.ReactModule;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
+
+/**
+ * Module that monitors and provides information about the state of Touch Exploration service
+ * on the device. For API >= 19.
+ */
+@ReactModule(name = "AccessibilityInfo")
+public class AccessibilityInfoModule extends ReactContextBaseJavaModule
+        implements LifecycleEventListener {
+
+    @TargetApi(19)
+    private class ReactTouchExplorationStateChangeListener
+            implements AccessibilityManager.TouchExplorationStateChangeListener {
+
+        @Override
+        public void onTouchExplorationStateChanged(boolean enabled) {
+            updateAndSendChangeEvent(enabled);
+        }
+    }
+
+    private @Nullable AccessibilityManager mAccessibilityManager;
+    private @Nullable ReactTouchExplorationStateChangeListener mTouchExplorationStateChangeListener;
+    private boolean mEnabled = false;
+
+    private static final String EVENT_NAME = "touchExplorationDidChange";
+
+    public AccessibilityInfoModule(ReactApplicationContext context) {
+        super(context);
+        mAccessibilityManager = (AccessibilityManager) getReactApplicationContext()
+                .getSystemService(Context.ACCESSIBILITY_SERVICE);
+        mEnabled = mAccessibilityManager.isTouchExplorationEnabled();
+        if (Build.VERSION.SDK_INT >= 19) {
+            mTouchExplorationStateChangeListener = new ReactTouchExplorationStateChangeListener();
+        }
+    }
+
+    @Override
+    public String getName() {
+        return "AccessibilityInfo";
+    }
+
+    @ReactMethod
+    public void isTouchExplorationEnabled(Callback successCallback) {
+        successCallback.invoke(mEnabled);
+    }
+
+    private void updateAndSendChangeEvent(boolean enabled) {
+        if (mEnabled != enabled) {
+            mEnabled = enabled;
+            getReactApplicationContext().getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                    .emit(EVENT_NAME, mEnabled);
+        }
+    }
+
+    @Override
+    public void onHostResume() {
+        if (Build.VERSION.SDK_INT >= 19) {
+            mAccessibilityManager.addTouchExplorationStateChangeListener(
+                    mTouchExplorationStateChangeListener);
+        }
+        updateAndSendChangeEvent(mAccessibilityManager.isTouchExplorationEnabled());
+    }
+
+    @Override
+    public void onHostPause() {
+        if (Build.VERSION.SDK_INT >= 19) {
+            mAccessibilityManager.removeTouchExplorationStateChangeListener(
+                    mTouchExplorationStateChangeListener);
+        }
+    }
+
+    @Override
+    public void initialize() {
+        getReactApplicationContext().addLifecycleEventListener(this);
+        updateAndSendChangeEvent(mAccessibilityManager.isTouchExplorationEnabled());
+    }
+
+    @Override
+    public void onHostDestroy() {
+    }
+}

--- a/sdk/android/skin/src/main/java/com/ooyala/android/skin/accessibility/AccessibilityInfoModule.java
+++ b/sdk/android/skin/src/main/java/com/ooyala/android/skin/accessibility/AccessibilityInfoModule.java
@@ -44,8 +44,8 @@ public class AccessibilityInfoModule extends ReactContextBaseJavaModule
 
     public AccessibilityInfoModule(ReactApplicationContext context) {
         super(context);
-        mAccessibilityManager = (AccessibilityManager) getReactApplicationContext()
-                .getSystemService(Context.ACCESSIBILITY_SERVICE);
+        Context appContext = context.getApplicationContext();
+        mAccessibilityManager = (AccessibilityManager) appContext.getSystemService(Context.ACCESSIBILITY_SERVICE);
         mEnabled = mAccessibilityManager.isTouchExplorationEnabled();
         if (Build.VERSION.SDK_INT >= 19) {
             mTouchExplorationStateChangeListener = new ReactTouchExplorationStateChangeListener();
@@ -91,6 +91,12 @@ public class AccessibilityInfoModule extends ReactContextBaseJavaModule
     public void initialize() {
         getReactApplicationContext().addLifecycleEventListener(this);
         updateAndSendChangeEvent(mAccessibilityManager.isTouchExplorationEnabled());
+    }
+
+    @Override
+    public void onCatalystInstanceDestroy() {
+        super.onCatalystInstanceDestroy();
+        getReactApplicationContext().removeLifecycleEventListener(this);
     }
 
     @Override

--- a/sdk/react/accessibility/AccessibilityInfo.android.js
+++ b/sdk/react/accessibility/AccessibilityInfo.android.js
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * TODO: Delete this file when updating to react native latest version
+ *
+ * @providesModule AccessibilityInfo
+ * @flow
+ */
+'use strict';
+
+var NativeModules = require('NativeModules');
+var RCTDeviceEventEmitter = require('RCTDeviceEventEmitter');
+
+var RCTAccessibilityInfo = NativeModules.AccessibilityInfo;
+
+var TOUCH_EXPLORATION_EVENT = 'touchExplorationDidChange';
+
+type ChangeEventName = $Enum<{
+  change: string,
+}>;
+
+var _subscriptions = new Map();
+
+var AccessibilityInfo = {
+
+  fetch: function(): Promise {
+    return new Promise((resolve, reject) => {
+      RCTAccessibilityInfo.isTouchExplorationEnabled(
+        function(resp) {
+          resolve(resp);
+        }
+      );
+    });
+  },
+
+  addEventListener: function (
+    eventName: ChangeEventName,
+    handler: Function
+  ): void {
+    var listener = RCTDeviceEventEmitter.addListener(
+      TOUCH_EXPLORATION_EVENT,
+      (enabled) => {
+        handler(enabled);
+      }
+    );
+    _subscriptions.set(handler, listener);
+  },
+
+  removeEventListener: function(
+    eventName: ChangeEventName,
+    handler: Function
+  ): void {
+    var listener = _subscriptions.get(handler);
+    if (!listener) {
+      return;
+    }
+    listener.remove();
+    _subscriptions.delete(handler);
+  },
+
+};
+
+module.exports = AccessibilityInfo;

--- a/sdk/react/accessibility/AccessibilityInfo.ios.js
+++ b/sdk/react/accessibility/AccessibilityInfo.ios.js
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * TODO: Delete this file when updating to react native latest version
+ *
+ * @providesModule AccessibilityInfo
+ * @flow
+ */
+'use strict';
+
+var NativeModules = require('NativeModules');
+var Promise = require('Promise');
+var RCTDeviceEventEmitter = require('RCTDeviceEventEmitter');
+
+var AccessibilityManager = NativeModules.AccessibilityManager;
+
+var VOICE_OVER_EVENT = 'voiceOverDidChange';
+
+type ChangeEventName = $Enum<{
+  change: string,
+}>;
+
+var _subscriptions = new Map();
+
+/**
+ * Sometimes it's useful to know whether or not the device has a screen reader that is currently active. The
+ * `AccessibilityInfo` API is designed for this purpose. You can use it to query the current state of the
+ * screen reader as well as to register to be notified when the state of the screen reader changes.
+ *
+ * Here's a small example illustrating how to use `AccessibilityInfo`:
+ *
+ * ```javascript
+ * class ScreenReaderStatusExample extends React.Component {
+ *   state = {
+ *     screenReaderEnabled: false,
+ *   }
+ *
+ *   componentDidMount() {
+ *     AccessibilityInfo.addEventListener(
+ *       'change',
+ *       this._handleScreenReaderToggled
+ *     );
+ *     AccessibilityInfo.fetch().done((isEnabled) => {
+ *       this.setState({
+ *         screenReaderEnabled: isEnabled
+ *       });
+ *     });
+ *   }
+ *
+ *   componentWillUnmount() {
+ *     AccessibilityInfo.removeEventListener(
+ *       'change',
+ *       this._handleScreenReaderToggled
+ *     );
+ *   }
+ *
+ *   _handleScreenReaderToggled = (isEnabled) => {
+ *     this.setState({
+ *       screenReaderEnabled: isEnabled,
+ *     });
+ *   }
+ *
+ *   render() {
+ *     return (
+ *       <View>
+ *         <Text>
+ *           The screen reader is {this.state.screenReaderEnabled ? 'enabled' : 'disabled'}.
+ *         </Text>
+ *       </View>
+ *     );
+ *   }
+ * }
+ * ```
+ */
+var AccessibilityInfo = {
+
+  /**
+   * Query whether a screen reader is currently enabled. Returns a promise which
+   * resolves to a boolean. The result is `true` when a screen reader is enabled
+   * and `false` otherwise.
+   */
+  fetch: function(): Promise {
+    return new Promise((resolve, reject) => {
+      AccessibilityManager.getCurrentVoiceOverState(
+        resolve,
+        reject
+      );
+    });
+  },
+
+  /**
+   * Add an event handler. Supported events:
+   *
+   * - `change`: Fires when the state of the screen reader changes. The argument
+   *   to the event handler is a boolean. The boolean is `true` when a screen
+   *   reader is enabled and `false` otherwise.
+   */
+  addEventListener: function (
+    eventName: ChangeEventName,
+    handler: Function
+  ): Object {
+    var listener = RCTDeviceEventEmitter.addListener(
+      VOICE_OVER_EVENT,
+      handler
+    );
+    _subscriptions.set(handler, listener);
+    return {
+      remove: AccessibilityInfo.removeEventListener.bind(null, eventName, handler),
+    };
+  },
+
+  /**
+   * Remove an event handler.
+   */
+  removeEventListener: function(
+    eventName: ChangeEventName,
+    handler: Function
+  ): void {
+    var listener = _subscriptions.get(handler);
+    if (!listener) {
+      return;
+    }
+    listener.remove();
+    _subscriptions.delete(handler);
+  },
+
+};
+
+module.exports = AccessibilityInfo;


### PR DESCRIPTION
Added a module for both iOS and Android to know about the current state of the screen readers for each platform.

Ask me if you want to test it out but I checked it by adding some snippets to both index.ios.js and index.android.js.

From here we need to customize the UI depending on the state of a screen reader, but that will come in a different PR.

Note that when we update to the latest version of react native, we will need to remove the files and changes applied with this PR, since they will be part of react native. With this PR we are just adding the Accessibility APIs added in newer versions of react native.