### PR TITLE
[PLAYER-1549] Added missing accessibility tags

### DIFF
--- a/sdk/react/bottomOverlay.js
+++ b/sdk/react/bottomOverlay.js
@@ -133,7 +133,7 @@ If the playhead position has changed, reset the cachedPlayhead to -1 so that it 
     var scrubberStyle = this._customizeScrubber();
 
     return (
-      <View accessible={true} accessibilityLabel={STRING_CONSTANTS.VIDEO_SEEK_SCRUBBER} style={[scrubberStyle, positionStyle,{width:scrubberSize, height:scrubberSize}]}>
+      <View style={[scrubberStyle, positionStyle,{width:scrubberSize, height:scrubberSize}]}>
       </View>
       );
   },

--- a/sdk/react/panels/discoveryPanel.js
+++ b/sdk/react/panels/discoveryPanel.js
@@ -271,7 +271,11 @@ var DiscoveryPanel = React.createClass({
       <Text style={[panelStyles.panelTitleText]}>
       {title}
       </Text>
-      <Text style={panelStyles.panelIcon}>{panelIcon}</Text>
+      <TouchableHighlight accessible={true} accessibilityLabel={BUTTON_NAMES.DISCOVERY}>
+        <View>
+          <Text style={panelStyles.panelIcon}>{panelIcon}</Text>
+        </View>
+      </TouchableHighlight>
       <View style={panelStyles.headerFlexibleSpace}></View>
       <TouchableHighlight 
         accessible={true} accessibilityLabel={BUTTON_NAMES.DISMISS} accessibilityComponentType="button"

--- a/sdk/react/panels/discoveryPanel.js
+++ b/sdk/react/panels/discoveryPanel.js
@@ -266,6 +266,9 @@ var DiscoveryPanel = React.createClass({
     title = Utils.localizedString(this.props.locale, "Discover", this.props.localizableStrings);
     var panelIcon = this.props.config.icons.discovery.fontString;
 
+    // TO-DO for line (277-280) we can not change accessibility label value for text tags.
+    // This ability is added in latest react native 0.46 onwards
+    // so we can remove this piece of code once we upgrade.
     return (
     <View style={panelStyles.panelTitleView}>
       <Text style={[panelStyles.panelTitleText]}>

--- a/sdk/react/panels/languageSelectionPanel.js
+++ b/sdk/react/panels/languageSelectionPanel.js
@@ -131,7 +131,11 @@ var LanguageSelectionPanel = React.createClass({
       <Text style={[panelStyles.panelTitleText]}>
       {title}
       </Text>
-      <Text style={panelStyles.panelIcon}>{panelIcon}</Text>
+      <TouchableHighlight accessible={true} accessibilityLabel={BUTTON_NAMES.CLOSED_CAPTIONS}>
+        <View>
+          <Text style={panelStyles.panelIcon}>{panelIcon}</Text>
+        </View>
+      </TouchableHighlight>
       <View style={panelStyles.headerFlexibleSpace}></View>
       <TouchableHighlight
         accessible={true} accessibilityLabel={BUTTON_NAMES.DISMISS} accessibilityComponentType="button"

--- a/sdk/react/panels/languageSelectionPanel.js
+++ b/sdk/react/panels/languageSelectionPanel.js
@@ -117,7 +117,9 @@ var LanguageSelectionPanel = React.createClass({
     else if (width < fullWidthPanelIcon) {
       panelIcon = "";
     }
-
+    // TO-DO for line (136-140) we can not change accessibility label value for text tags.
+    // This ability is added in latest react native 0.46 onwards
+    // so we can remove this piece of code once we upgrade.
     return (
     <View style={panelStyles.panelTitleView}>
       <ToggleSwitch


### PR DESCRIPTION
I have added missing tags for "closed captions" and "discovery". 
To make it work I have to wrap icon with TouchableHighlight. Reason for that icon is of type Text and we can not change accessibility label for text. This ability is added in latest react native so we can remove this piece of code once we upgrade.

