### PR TITLE
[PLAYER-1552] Video player area acts as play/pause button (ScreenReader enabled)

### DIFF
--- a/sdk/react/accessibility/AccessibilityInfo.ios.js
+++ b/sdk/react/accessibility/AccessibilityInfo.ios.js
@@ -115,6 +115,15 @@ var AccessibilityInfo = {
   },
 
   /**
+   * iOS-Only. Set accessibility focus to a react component.
+   */
+  setAccessibilityFocus: function(
+    reactTag: number
+  ): void {
+    AccessibilityManager.setAccessibilityFocus(reactTag);
+  },
+
+  /**
    * Remove an event handler.
    */
   removeEventListener: function(

--- a/sdk/react/index.ios.js
+++ b/sdk/react/index.ios.js
@@ -75,6 +75,8 @@ var OoyalaSkin = React.createClass({
         screenReaderEnabled: isEnabled
       });
     });
+
+    AccessibilityInfo.setAccessibilityFocus(1);
   },
 
   componentWillUnmount: function() {

--- a/sdk/react/panels/StartScreen.js
+++ b/sdk/react/panels/StartScreen.js
@@ -108,16 +108,16 @@ var StartScreen = React.createClass({
       var fullscreen = (this.props.config.startScreen.promoImageSize == 'default');
 
       return (
-        <Image 
+        <Image
           source={{uri: this.props.promoUrl}}
-          style={fullscreen ? 
+          style={fullscreen ?
             {position:'absolute', top:0, left:0, width:this.props.width, height: this.props.height} :
              styles.promoImageSmall}
           resizeMode={Image.resizeMode.contain}>
         </Image>
       );
     }
-    
+
     return null;
   },
 
@@ -125,24 +125,28 @@ var StartScreen = React.createClass({
     var waterMarkImageLocation = styles.waterMarkImageSE;
     return (
       <Image style={[styles.waterMarkImage, waterMarkImageLocation]}
-        source={{uri: IMG_URLS.OOYALA_LOGO}} 
+        source={{uri: IMG_URLS.OOYALA_LOGO}}
         resizeMode={Image.resizeMode.contain}>
       </Image>
     );
   },
 
-  render: function() {  
+  render: function() {
     var promoImage = this.getPromoImage();
     var playButton = this.getPlayButton();
     var infoPanel = this.getInfoPanel();
     var waterMarkImage = this.getWaterMark();
- 
+
 
     return (
-     <View style={styles.container}>
+     <View
+     reactTag={1}
+     accessible={true}
+     accessibilityLabel={"Video player. Tap twice to play"}
+     style={styles.container}>
        {promoImage}
        {waterMarkImage}
-       {infoPanel} 
+       {infoPanel}
        {playButton}
       </View>
    );

--- a/sdk/react/panels/videoView.js
+++ b/sdk/react/panels/videoView.js
@@ -118,6 +118,14 @@ var VideoView = React.createClass({
     }
   },
 
+  _placeholderTapHandler: function(event) {
+    if (this.props.screenReaderEnabled) {
+      this.handlePress(BUTTON_NAMES.PLAY_PAUSE);
+    } else {
+      this.props.handlers.handleVideoTouch(event);
+    }
+  },
+
   _createOnIcon: function(index, func) {
     return function() {
       func(index);
@@ -158,10 +166,11 @@ var VideoView = React.createClass({
   _renderPlaceholder: function() {
     return (
       <View
+        reactTag={1}
         accessible={true}
-        accessibilityLabel={"Video player"}
+        accessibilityLabel={"Video player. Tap twice to play or pause"}
         style={styles.placeholder}
-        onTouchEnd={(event) => this.props.handlers.handleVideoTouch(event)}>
+        onTouchEnd={(event) => this._placeholderTapHandler(event)}>
       </View>);
   },
 
@@ -356,7 +365,8 @@ var VideoView = React.createClass({
   render: function() {
     var isPastAutoHideTime = (new Date).getTime() - this.props.lastPressedTime > AUTOHIDE_DELAY;
     var shouldShowControls = this.props.screenReaderEnabled ? true : !isPastAutoHideTime;
-    
+
+    // for renderPlayPause, if the screen reader is enabled, we want to hide the button
     return (
       <View
         accessible={false}
@@ -364,7 +374,7 @@ var VideoView = React.createClass({
         {this._renderPlaceholder()}
         {this._renderBottom()}
         {this._renderAdOverlay()}
-        {this._renderPlayPause(shouldShowControls)}
+        {this._renderPlayPause(this.props.screenReaderEnabled ? false : shouldShowControls)}
         {this._renderUpNext()}
         {this._renderBottomOverlay(shouldShowControls)}
         {this._renderLoading()}

--- a/sdk/react/widgets/VideoViewPlayPause.js
+++ b/sdk/react/widgets/VideoViewPlayPause.js
@@ -38,7 +38,7 @@ var VideoViewPlayPause = React.createClass({
     initialPlay: React.PropTypes.bool
   },
 
-  getInitialState: function() {      
+  getInitialState: function() {
     return {
       play: {
         animationScale: new Animated.Value(1),
@@ -146,10 +146,10 @@ var VideoViewPlayPause = React.createClass({
     var size = {position: 'absolute'};
 
     return (
-      
-      <View accessible={true} accessibilityLabel={this.state.play.animationOpacity._value ? "play" : "pause"} accessibilityComponentType="button" 
-         style={[size]}> 
-        <Animated.Text accessible={false} 
+
+      <View accessible={false} 
+         style={[size]}>
+        <Animated.Text accessible={false}
           style={[styles.buttonTextStyle, fontStyle, buttonColor, this.props.buttonStyle, animate, opacity]}>
           {this.props.icons[name].icon}
         </Animated.Text>
@@ -172,9 +172,9 @@ var VideoViewPlayPause = React.createClass({
     if(this.props.style != null) {
       positionStyle = this.props.style;
     }
-    
+
     else if (this.props.position == "center") {
-      
+
       var topOffset = Math.round((this.props.frameHeight - this.props.buttonHeight * scaleMultiplier) * 0.5);
       var leftOffset = Math.round((this.props.frameWidth - this.props.buttonWidth * scaleMultiplier) * 0.5);
 
@@ -184,7 +184,7 @@ var VideoViewPlayPause = React.createClass({
     } else {
       positionStyle = styles[this.props.position];
     }
-    
+
     var sizeStyle = {width: this.props.buttonWidth, height: this.props.buttonHeight};
     var opacity = {opacity: this.state.widget.animationOpacity};
 
@@ -203,7 +203,7 @@ var VideoViewPlayPause = React.createClass({
         sizeStyle.paddingRight = this.props.buttonWidth;
         sizeStyle.height = this.props.buttonHeight * scaleMultiplier;
         sizeStyle.width = this.props.buttonWidth * scaleMultiplier;
-        
+
         return (
           <TouchableHighlight
             onPress={() => this.onPress()}
@@ -222,7 +222,7 @@ var VideoViewPlayPause = React.createClass({
     }
     else{
       return (
-        <TouchableHighlight 
+        <TouchableHighlight
           onPress={() => this.onPress()}
           style={[positionStyle]}
           underlayColor="transparent"


### PR DESCRIPTION
We always hide the play/pause button when the screen reader is enabled. Also, if the screen reader is enabled the player view area acts as play/pause button if you double tap on it. This way the play/pause button doesn't interfiere with the video content as it was always in the middle of the screen.

Also added some new methods in AccessibilityInfo.ios.js to force focus in iOS. Without it, the first time the user enters the player view it will not be able to focus on it with the screen reader until the user taps on it.