### PR TITLE
[PBA-5915] Comment out setAccessibilityFocus usage

### DIFF
--- a/sdk/react/index.ios.js
+++ b/sdk/react/index.ios.js
@@ -76,7 +76,8 @@ var OoyalaSkin = React.createClass({
       });
     });
 
-    AccessibilityInfo.setAccessibilityFocus(1);
+    // TODO: Figure out how to add setAccessibilityFocus method from the ObjC side
+    // AccessibilityInfo.setAccessibilityFocus(1);
   },
 
   componentWillUnmount: function() {


### PR DESCRIPTION
setAccessibilityFocus is not part of the code in react native 0.35.0. We need to come up with a way to have it available in this version.

Right now the work around is just to comment out wherever we used it.