### PR TITLE
[PBA-5937] Use Slider when Screen reader is enabled on iOS

### DIFF
--- a/sdk/react/panels/videoView.js
+++ b/sdk/react/panels/videoView.js
@@ -155,6 +155,7 @@ var VideoView = React.createClass({
       showClosedCaptionsButton={shouldShowClosedCaptionsButton}
       showWatermark={this.props.showWatermark}
       isShow={show}
+      screenReaderEnabled={this.props.screenReaderEnabled}
       config={{
         controlBar: this.props.config.controlBar,
         buttons: this.props.config.buttons,


### PR DESCRIPTION
When accessibility is enabled, we want to use the native slider view from Apple to render the scrubber bar of the player. We do that to allow a user to change the value of the scrubber bar when accessibility is enabled.