### PR TITLE
[PLAYER-1778] Fix layout for iOS platform

### DIFF
--- a/sdk/react/controlBar.js
+++ b/sdk/react/controlBar.js
@@ -150,7 +150,8 @@ var ControlBar = React.createClass({
         showVolume: this.state.showVolume,
         volume: this.props.volume,
         scrubberStyle: styles.volumeSlider,
-        volumeControlColor: this.getVolumeControlColor()
+        volumeControlColor: this.getVolumeControlColor(),
+        platform: this.props.platform
       },
       timeDuration: {
         onPress: this.props.live ? this.props.live.onGoLive : null,

--- a/sdk/react/widgets/controlBarWidgets.js
+++ b/sdk/react/widgets/controlBarWidgets.js
@@ -48,16 +48,13 @@ var controlBarWidget = React.createClass({
 
   volumeWidget: function (options) {
     var volumeScrubber = null;
+    const scrubberStyle = [options.scrubberStyle];
+    if (options.platform === Constants.PLATFORMS.IOS) {
+        scrubberStyle.push({top: 5});
+    }
     if (options.showVolume) {
         volumeScrubber = <VolumeView
-            style={
-                [
-                    options.scrubberStyle,
-                    {
-                        top: (options.platform === Constants.PLATFORMS.IOS) ? 5 : undefined,
-                    },
-                ]
-            }
+            style={scrubberStyle}
             color={options.volumeControlColor}
             volume={options.volume} />;
     }

--- a/sdk/react/widgets/controlBarWidgets.js
+++ b/sdk/react/widgets/controlBarWidgets.js
@@ -49,7 +49,17 @@ var controlBarWidget = React.createClass({
   volumeWidget: function (options) {
     var volumeScrubber = null;
     if (options.showVolume) {
-        volumeScrubber = <VolumeView style={options.scrubberStyle} color={options.volumeControlColor} volume={options.volume} />;
+        volumeScrubber = <VolumeView
+            style={
+                [
+                    options.scrubberStyle,
+                    {
+                        top: (options.platform === Constants.PLATFORMS.IOS) ? 5 : undefined,
+                    },
+                ]
+            }
+            color={options.volumeControlColor}
+            volume={options.volume} />;
     }
 
     var iconConfig = (options.volume > 0) ? options.iconOn : options.iconOff;


### PR DESCRIPTION
This fix looks like a crutch, but it's not.
Layout is actually ok - i can't reproduce this bug with android. But both platform use their own native element for volume slider.
MPVolumeView's positioning have some kind of bug (or something that i just can't understand).
During my investigation i wrapped VolumeView in a simple React Native View and tried to positioning it.  Wrapper View was ok (aligned just how it should be), but Volume View just go out from super view's borders. 
So, finally, bug is definitely not in layout. There is problem with MPVolumeView, which is always has 
"Y: -5" instead of "Y: 0"  (tested with iPad pro, ipod touch, iphone 6).
This fix resolve bug for these devices and has no effect with Android.