### PR TITLE
[PLAYER-3408]  Multi audio: audio tracks order is the same for all the platforms.

### DIFF
--- a/sdk/android/skin/src/main/java/com/ooyala/android/skin/BridgeMessageBuilder.java
+++ b/sdk/android/skin/src/main/java/com/ooyala/android/skin/BridgeMessageBuilder.java
@@ -23,6 +23,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 
 class BridgeMessageBuilder {
@@ -326,7 +327,7 @@ class BridgeMessageBuilder {
    *
    * @param audioTracks The list of available audio tracks for the current asset.
    */
-  public static WritableMap buildMultiAudioParams(Set<AudioTrack> audioTracks) {
+  public static WritableMap buildMultiAudioParams(List<AudioTrack> audioTracks) {
     WritableMap params = Arguments.createMap();
     WritableArray audioTracksTitles = Arguments.createArray();
 

--- a/sdk/android/skin/src/main/java/com/ooyala/android/skin/OoyalaSkinPlayerObserver.java
+++ b/sdk/android/skin/src/main/java/com/ooyala/android/skin/OoyalaSkinPlayerObserver.java
@@ -12,10 +12,10 @@ import com.ooyala.android.item.ClosedCaptions;
 import com.ooyala.android.player.exoplayer.multiaudio.AudioTrack;
 import com.ooyala.android.util.DebugMode;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Observable;
 import java.util.Observer;
-import java.util.Set;
 
 /**
  * The class that solely listens to the OoyalaPlayer, and responds based on the events
@@ -229,7 +229,7 @@ class OoyalaSkinPlayerObserver implements Observer {
    * Send the notification to Skin if multi audio is enabled or not for the current asset.
    */
   private void bridgeMultiAudioEnabledNotification() {
-    Set<AudioTrack> audioTracks = _player.getAvailableAudioTracks();
+    List<AudioTrack> audioTracks = _player.getAvailableAudioTracks();
     WritableMap params = BridgeMessageBuilder.buildMultiAudioParams(audioTracks);
     _layoutController.sendEvent(OoyalaPlayer.MULTI_AUDIO_ENABLED_NOTIFICATION_NAME, params);
   }


### PR DESCRIPTION
I replaced unordered Set on List to keep audio tracks in ordered sequence of elements.