### PR TITLE
[PLAYER-3149] - [Apple TV] Closed captions are not shown when selected in TV settings.

### DIFF
--- a/sdk/tvOS/OoyalaTVSkinSDK/OOOoyalaTVPlayerViewController.m
+++ b/sdk/tvOS/OoyalaTVSkinSDK/OOOoyalaTVPlayerViewController.m
@@ -53,7 +53,6 @@ static OOClosedCaptionsStyle *_closedCaptionsStyle;
   if (self = [super init]) {
     [self setPlayer:player];
   }
-    
   return self;
 }
 
@@ -268,6 +267,7 @@ static OOClosedCaptionsStyle *_closedCaptionsStyle;
     if (self.player.currentItem.hasClosedCaptions && !self.closedCaptionMenuDisplayed){
         self.closedCaptionsMenuBar.alpha = self.progressBarBackground.alpha;
     }
+    [self.player removeClosedCaptionsDuplicate];
 }
 
 - (UIView *)preferredFocusedView {

--- a/sdk/tvOS/OoyalaTVSkinSDK/OOOoyalaTVPlayerViewController.m
+++ b/sdk/tvOS/OoyalaTVSkinSDK/OOOoyalaTVPlayerViewController.m
@@ -268,7 +268,7 @@ static OOClosedCaptionsStyle *_closedCaptionsStyle;
     if (self.player.currentItem.hasClosedCaptions && !self.closedCaptionMenuDisplayed){
         self.closedCaptionsMenuBar.alpha = self.progressBarBackground.alpha;
     }
-    [self.player removeClosedCaptionsDuplicate];
+    [self.player disablePlaylistClosedCaptions];
 }
 
 - (UIView *)preferredFocusedView {

--- a/sdk/tvOS/OoyalaTVSkinSDK/OOOoyalaTVPlayerViewController.m
+++ b/sdk/tvOS/OoyalaTVSkinSDK/OOOoyalaTVPlayerViewController.m
@@ -53,6 +53,7 @@ static OOClosedCaptionsStyle *_closedCaptionsStyle;
   if (self = [super init]) {
     [self setPlayer:player];
   }
+    
   return self;
 }
 


### PR DESCRIPTION
Calling SDK method to avoid CC duplicates when using Skin SDK.

https://jira.corp.ooyala.com/browse/PLAYER-3149