### PR TITLE
[PLAYER-3610] AudioAndCCSelectionPanel: selected localized item check

### DIFF
--- a/sdk/react/panels/AudioAndCCSelectionPanel.js
+++ b/sdk/react/panels/AudioAndCCSelectionPanel.js
@@ -137,8 +137,10 @@ const AudioAndCCSelectionPanel = React.createClass({
     // Localize selected item
 
     let selectedLocalizedItem = this.props.selectedAudioTrackTitle;
-    selectedLocalizedItem = selectedLocalizedItem.replace(stringConstants.undefinedLanguageTitle, localizedTitleForUndefinedLanguage);
-    selectedLocalizedItem = selectedLocalizedItem.replace(stringConstants.noLinguisticContentTitle, localizedTitleForUndefinedLanguage);
+    if (selectedLocalizedItem !== undefined) {
+      selectedLocalizedItem = selectedLocalizedItem.replace(stringConstants.undefinedLanguageTitle, localizedTitleForUndefinedLanguage);
+      selectedLocalizedItem = selectedLocalizedItem.replace(stringConstants.noLinguisticContentTitle, localizedTitleForUndefinedLanguage);
+    }
 
     // Localize other items
 


### PR DESCRIPTION
Description: an application crashes if user minimizes it while Multi-audio menu is opened.