### PR TITLE
[PBA-6322] OoyalaReactBridge: null check is added for params in sendEvent method

### DIFF
--- a/sdk/android/skin/src/main/java/com/ooyala/android/skin/OoyalaReactBridge.java
+++ b/sdk/android/skin/src/main/java/com/ooyala/android/skin/OoyalaReactBridge.java
@@ -39,7 +39,9 @@ public class OoyalaReactBridge extends ReactContextBaseJavaModule implements Bri
     if (context.hasActiveCatalystInstance()) {
       context.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class).emit(eventName, params);
     } else {
-      DebugMode.logW("TAG", "Trying to send an event without an active Catalyst Instance: " + eventName + ", Params:" + params.toString());
+      String paramsInfo = params != null ? params.toString() : "is null";
+      DebugMode.logW("TAG", "Trying to send an event without an active Catalyst Instance: "
+        + eventName + ", Params: " + paramsInfo);
     }
   }
 


### PR DESCRIPTION
Issue: Random crashes while using Ooyala cast sdk.
I couldn't reproduce the issue, fixed it using a crash logs only.