### PR TITLE
[Player-4078] Removed redundant component name

### DIFF
--- a/sdk/react/widgets/SkipButton.js
+++ b/sdk/react/widgets/SkipButton.js
@@ -42,7 +42,6 @@ class SkipButton extends React.Component {
       <TouchableHighlight
         accessible={true}
         accessibilityLabel={accessibilityLabel}
-        accessibilityComponentType="button"
         onPress={() => this.onPress()}
         underlayColor="transparent"
         importantForAccessibility={'yes'}

--- a/sdk/react/widgets/VideoViewPlayPause.js
+++ b/sdk/react/widgets/VideoViewPlayPause.js
@@ -99,7 +99,6 @@ class VideoViewPlayPause extends React.Component {
       <TouchableHighlight
         accessible={true}
         accessibilityLabel={label}
-        accessibilityComponentType="button"
         onPress={() => this.onPress()}
         underlayColor="transparent"
         activeOpacity={this.props.opacity}


### PR DESCRIPTION
https://jira.corp.ooyala.com/browse/PLAYER-4078
TalkBack announces component type after accessibility label. 
Accessibility label gives enough information about buttons so component type, in this case, is redundant.