### PR TITLE
[PLAYER-4060] Seek visibility for VOD videos fix

### DIFF
--- a/sdk/react/panels/videoView.js
+++ b/sdk/react/panels/videoView.js
@@ -273,7 +273,7 @@ class VideoView extends React.Component {
 
   _renderPlayPause = (show) => {
     const iconFontSize = ResponsiveDesignManager.makeResponsiveMultiplier(this.props.width, UI_SIZES.VIDEOVIEW_PLAYPAUSE);
-    const seekVisible = !this.props.config.live.forceDvrDisabled;
+    const seekVisible = !this.props.config.live.forceDvrDisabled || !this.props.live;
     const notInLiveRegion = this.props.playhead <= this.props.duration * VALUES.LIVE_THRESHOLD;
     return (
       <VideoViewPlayPause


### PR DESCRIPTION
4060 has been reopened - fix affected not only live videos but also VODs. With `forceDvrDisabled = true` seek buttons were hidden.
Basically, I forgot to add a condition -  when DVR Forced hide seek buttons **only** for live videos.

