### PR TITLE
[PLAYER-4120] Hidden play button to avoid double "play" event

### DIFF
--- a/sdk/react/panels/StartScreen.js
+++ b/sdk/react/panels/StartScreen.js
@@ -78,7 +78,7 @@ class StartScreen extends React.Component {
           platform={this.props.platform}
           fontSize={iconFontSize}
           playing={false}
-          showButton={true}
+          showButton={!this.props.screenReaderEnabled}
           initialPlay={true}/>
       );
     }


### PR DESCRIPTION
Play button at the start screen hidden for TalkBack to avoid duplication of "PLay" event which causes a restart of IMA videos. More info you can find in the ticket https://jira.corp.ooyala.com/browse/PLAYER-4120