### PR TITLE
[PLAYER-4076][PLAYER-4077] Re-add filtering seek values between 1-99

### DIFF
--- a/sdk/react/panels/videoView.js
+++ b/sdk/react/panels/videoView.js
@@ -125,9 +125,9 @@ class VideoView extends React.Component {
     if (skipCountValue == 0) { return null; }
 
     let configSeekValue = (skipCountValue > 0) ? this.props.config.skipControls.skipForwardTime : this.props.config.skipControls.skipBackwardTime;
-    //configSeekValue = Utils.restrictSeekValueIfNeeded(configSeekValue);
+    configSeekValue = Utils.restrictSeekValueIfNeeded(configSeekValue);
     const seekValue = configSeekValue * skipCountValue;
-    
+
     const currentPlayhead = this.props.playhead;
     let resultedPlayhead = currentPlayhead + seekValue;
     if (resultedPlayhead < 0) {


### PR DESCRIPTION
I didn't see any issue in re-adding this filter option. I think SPB was confused about the requirement. It's ok to go beyond 99 if you sum up the seek actions, but a single seek action should not be out of the 1-99 range.