### PR TITLE
[PLAYER-3615] Added UIDeviceOrientationFaceUp and UIDeviceOrientationFaceDown to ignored for fullscreen logic

### DIFF
--- a/sdk/iOS/OoyalaSkinSDK/ViewControllers/OOSkinViewController.m
+++ b/sdk/iOS/OoyalaSkinSDK/ViewControllers/OOSkinViewController.m
@@ -542,6 +542,15 @@ NSString *const OOSkinViewControllerFullscreenChangedNotification = @"fullScreen
 
 - (void)orientationChanged:(NSNotification *)notification {
   UIDeviceOrientation orientation = UIDevice.currentDevice.orientation;
+  
+  // Ignore FaceUp and FaceDown orienations
+  
+  if (orientation == UIDeviceOrientationFaceUp || orientation == UIDeviceOrientationFaceDown) {
+    return;
+  }
+  
+  // Change fullscreen
+  
   BOOL isLandscapeOrientation = UIDeviceOrientationIsLandscape(orientation);
   
   if (self.isAutoFullscreenWithRotatedEnabled && !self.isVRStereoMode) {


### PR DESCRIPTION
- fixed bug with unsupported behavior with ```UIDeviceOrientationFaceUp``` and ```UIDeviceOrientationFaceDown``` orientations
Ticket: https://jira.corp.ooyala.com/browse/PLAYER-3615