### PR TITLE
[PLAYER-4483] Fixed app crash when removed playback speed options from skin.json

### DIFF
--- a/sdk/react/ooyalaSkinPanelRenderer.js
+++ b/sdk/react/ooyalaSkinPanelRenderer.js
@@ -88,7 +88,7 @@ OoyalaSkinPanelRenderer.prototype.renderVideoView = function() {
 
   if (this.skin.props.playbackSpeed && Array.isArray(this.skin.props.playbackSpeed.options)) {
     playbackSpeedEnabled = this.skin.state.playbackSpeedEnabled && this.skin.props.playbackSpeed.options.length > 2;
-  } 
+  }
 
   return (
     <VideoView
@@ -220,14 +220,12 @@ OoyalaSkinPanelRenderer.prototype.renderAudioAndCCSelectionPanel = function() {
 };
 
 OoyalaSkinPanelRenderer.prototype.renderPlaybackSpeedPanel = function() {
-  let playbackSpeedRates;
-
+  let playbackSpeedRates = [];
   if (this.skin.props.playbackSpeed && Array.isArray(this.skin.props.playbackSpeed.options)) {
     playbackSpeedRates = this.skin.props.playbackSpeed.options;
-  } else {
-    playbackSpeedRates = [];
   }
-  return (  
+
+  return (
     <PlaybackSpeedPanel
       playbackSpeedRates={playbackSpeedRates}
       selectedPlaybackSpeedRate={this.skin.state.selectedPlaybackSpeedRate}

--- a/sdk/react/ooyalaSkinPanelRenderer.js
+++ b/sdk/react/ooyalaSkinPanelRenderer.js
@@ -86,7 +86,7 @@ OoyalaSkinPanelRenderer.prototype.renderErrorScreen = function() {
 OoyalaSkinPanelRenderer.prototype.renderVideoView = function() {
   let playbackSpeedEnabled = false;
 
-  if (Array.isArray(this.skin.props.playbackSpeed.options)) {
+  if (this.skin.props.playbackSpeed && Array.isArray(this.skin.props.playbackSpeed.options)) {
     playbackSpeedEnabled = this.skin.state.playbackSpeedEnabled && this.skin.props.playbackSpeed.options.length > 2;
   } 
 
@@ -220,9 +220,16 @@ OoyalaSkinPanelRenderer.prototype.renderAudioAndCCSelectionPanel = function() {
 };
 
 OoyalaSkinPanelRenderer.prototype.renderPlaybackSpeedPanel = function() {
-  return (
+  let playbackSpeedRates;
+
+  if (this.skin.props.playbackSpeed && Array.isArray(this.skin.props.playbackSpeed.options)) {
+    playbackSpeedRates = this.skin.props.playbackSpeed.options;
+  } else {
+    playbackSpeedRates = [];
+  }
+  return (  
     <PlaybackSpeedPanel
-      playbackSpeedRates={this.skin.props.playbackSpeed.options}
+      playbackSpeedRates={playbackSpeedRates}
       selectedPlaybackSpeedRate={this.skin.state.selectedPlaybackSpeedRate}
       width={this.skin.state.width}
       height={this.skin.state.height}


### PR DESCRIPTION
- fixed app crash when removed playback speed options from skin.json

Unit tests not included.
Ticket: https://jira.corp.ooyala.com:8443/browse/PLAYER-4483