### PR TITLE
[Player-3962] Not pausing videos on clicking subtitles/multi-language button

### DIFF
--- a/sdk/react/ooyalaSkinBridgeListener.js
+++ b/sdk/react/ooyalaSkinBridgeListener.js
@@ -114,6 +114,7 @@ OoyalaSkinBridgeListener.prototype.onAdStarted = function(e) {
     screenType:SCREEN_TYPES.VIDEO_SCREEN,
     adOverlay: null
   });
+  this.core.clearOverlayStack();
 };
 
 OoyalaSkinBridgeListener.prototype.onCcStylingChange = function(e) {

--- a/sdk/react/ooyalaSkinCore.js
+++ b/sdk/react/ooyalaSkinCore.js
@@ -93,7 +93,7 @@ OoyalaSkinCore.prototype.handleMoreOptionsButtonPress = function(buttonName) {
     case BUTTON_NAMES.SETTING:
       break;
     case BUTTON_NAMES.AUDIO_AND_CC:
-      this.pushToOverlayStackAndMaybePause(OVERLAY_TYPES.AUDIO_AND_CC_SCREEN);
+      this.pushToOverlayStack(OVERLAY_TYPES.AUDIO_AND_CC_SCREEN);
       break;
     case BUTTON_NAMES.PLAYBACK_SPEED:
       this.pushToOverlayStackAndMaybePause(OVERLAY_TYPES.PLAYBACK_SPEED_SCREEN);
@@ -115,7 +115,7 @@ OoyalaSkinCore.prototype.handleMoreOptionsButtonPress = function(buttonName) {
 OoyalaSkinCore.prototype.handlePress = function(n) {
   switch(n) {
     case BUTTON_NAMES.MORE:
-      this.pushToOverlayStack(OVERLAY_TYPES.MOREOPTION_SCREEN);
+      this.pushToOverlayStackAndMaybePause(OVERLAY_TYPES.MOREOPTION_SCREEN);
       break;
     case BUTTON_NAMES.DISCOVERY:
       this.pushToOverlayStackAndMaybePause(OVERLAY_TYPES.DISCOVERY_SCREEN);

--- a/sdk/react/ooyalaSkinCore.js
+++ b/sdk/react/ooyalaSkinCore.js
@@ -115,7 +115,7 @@ OoyalaSkinCore.prototype.handleMoreOptionsButtonPress = function(buttonName) {
 OoyalaSkinCore.prototype.handlePress = function(n) {
   switch(n) {
     case BUTTON_NAMES.MORE:
-      this.pushToOverlayStackAndMaybePause(OVERLAY_TYPES.MOREOPTION_SCREEN);
+      this.pushToOverlayStack(OVERLAY_TYPES.MOREOPTION_SCREEN);
       break;
     case BUTTON_NAMES.DISCOVERY:
       this.pushToOverlayStackAndMaybePause(OVERLAY_TYPES.DISCOVERY_SCREEN);

--- a/sdk/react/ooyalaSkinCore.js
+++ b/sdk/react/ooyalaSkinCore.js
@@ -121,7 +121,7 @@ OoyalaSkinCore.prototype.handlePress = function(n) {
       this.pushToOverlayStackAndMaybePause(OVERLAY_TYPES.DISCOVERY_SCREEN);
       break;
     case BUTTON_NAMES.AUDIO_AND_CC:
-      this.pushToOverlayStackAndMaybePause(OVERLAY_TYPES.AUDIO_AND_CC_SCREEN);
+      this.pushToOverlayStack(OVERLAY_TYPES.AUDIO_AND_CC_SCREEN);
       break;
     case BUTTON_NAMES.PLAYBACK_SPEED:
       this.pushToOverlayStackAndMaybePause(OVERLAY_TYPES.PLAYBACK_SPEED_SCREEN);
@@ -255,10 +255,14 @@ OoyalaSkinCore.prototype.handleControlsTouch = function() {
 
 OoyalaSkinCore.prototype.pushToOverlayStackAndMaybePause = function(overlay) {
   if (this.skin.state.overlayStack.length === 0 && this.skin.state.playing) {
-    Log.log("New stack of overlays, pausing")
+    Log.log("New stack of overlays, pausing");
     this.skin.setState({pausedByOverlay:true});
     this.bridge.onPress({name:BUTTON_NAMES.PLAY_PAUSE});
   }
+  this.pushToOverlayStack(overlay)
+};
+
+OoyalaSkinCore.prototype.pushToOverlayStack = function(overlay) {
   var retVal = this.skin.state.overlayStack.push(overlay);
   this.skin.forceUpdate();
   return retVal;


### PR DESCRIPTION
[iOS][Android][OoyalaSkinSampleApp] Implemented not to pause any video on clicking subtitles/multi-language button, also when advertising starts if subtitles/multi-language menu is opened it will be closed.

iOS team, please first test on your devices, I was able to test on Android only.