### PR TITLE
[Player-4692] Vast icon did not appear

### DIFF
--- a/sdk/react/panels/adPlaybackScreen.js
+++ b/sdk/react/panels/adPlaybackScreen.js
@@ -277,7 +277,7 @@ class AdPlaybackScreen extends React.Component {
       }
       return (
         <View
-          style={styles.container}>
+          style={styles.adContainer}>
           {adBar}
           {this._renderPlaceholder(adIcons)}
           {playButtonIfPaused}
@@ -286,7 +286,7 @@ class AdPlaybackScreen extends React.Component {
     } else {
       return (
         <View
-          style={styles.container}>
+          style={styles.adContainer}>
           {adBar}
           {this._renderPlaceholder(adIcons)}
           {this._renderPlayPause(this.props.screenReaderEnabled ? false : shouldShowControls) }

--- a/sdk/react/panels/style/videoViewStyles.json
+++ b/sdk/react/panels/style/videoViewStyles.json
@@ -10,6 +10,12 @@
     "backgroundColor": "transparent",
     "overflow": "hidden"
   },
+  "adContainer": {
+    "flex": 1,
+    "flexDirection": "column",
+    "backgroundColor": "transparent",
+    "overflow": "hidden"
+  },
   "placeholder" : {
     "flex": 1,
     "alignItems": "stretch",


### PR DESCRIPTION
It was regression from PLAYER-4692, adPlaybackscreen and videoView using same container style. In PLAYER-4692 container was changed. I introduce adContainer in VideoViewStyles.json with reverted flex value.