### PR TITLE
Tint color for TV Player view controller

### DIFF
--- a/sdk/tvOS/OoyalaTVSkinSDK/OOOoyalaTVPlayerViewController.h
+++ b/sdk/tvOS/OoyalaTVSkinSDK/OOOoyalaTVPlayerViewController.h
@@ -18,6 +18,12 @@
  */
 @property (nonatomic) BOOL playbackControlsEnabled;
 
+/*!
+ @property progressTintColor
+ @abstract The color that will be used to tint the player's progress bar.
+ */
+@property (strong, nonatomic) UIColor *progressTintColor;
+
 - (instancetype)initWithPlayer:(OOOoyalaPlayer *)player;
 
 /**

--- a/sdk/tvOS/OoyalaTVSkinSDK/OOOoyalaTVPlayerViewController.h
+++ b/sdk/tvOS/OoyalaTVSkinSDK/OOOoyalaTVPlayerViewController.h
@@ -22,7 +22,7 @@
  @property progressTintColor
  @abstract The color that will be used to tint the player's progress bar.
  */
-@property (strong, nonatomic) UIColor *progressTintColor;
+@property (nonatomic) UIColor *progressTintColor;
 
 - (instancetype)initWithPlayer:(OOOoyalaPlayer *)player;
 

--- a/sdk/tvOS/OoyalaTVSkinSDK/OOOoyalaTVPlayerViewController.m
+++ b/sdk/tvOS/OoyalaTVSkinSDK/OOOoyalaTVPlayerViewController.m
@@ -68,6 +68,12 @@ static OOClosedCaptionsStyle *_closedCaptionsStyle;
 
 - (void)viewWillAppear:(BOOL)animated {
   [super viewWillAppear: animated];
+  if (!self.progressTintColor) {
+    self.progressTintColor = [UIColor colorWithRed:68.0/255.0
+                                             green:138.0/255.0
+                                             blue:225.0/255.0
+                                             alpha:1.0];
+  }
 
   [self setupViewController];
   if (!self.gestureManager) {
@@ -114,7 +120,7 @@ static OOClosedCaptionsStyle *_closedCaptionsStyle;
 }
 
 - (void)setupBars {
-  self.bottomBars = [[OOOoyalaTVBottomBars alloc] initWithBackground:self.progressBarBackground];
+  self.bottomBars = [[OOOoyalaTVBottomBars alloc] initWithBackground:self.progressBarBackground withTintColor:self.progressTintColor];
   //Adding button to indicate that CCs are available
   self.closedCaptionsMenuBar = [[OOOoyalaTVTopBar alloc] initMiniView:self.view];
   self.closedCaptionsMenuBar.alpha = 0.0;

--- a/sdk/tvOS/OoyalaTVSkinSDK/Widgets/OOOoyalaTVBottomBars.h
+++ b/sdk/tvOS/OoyalaTVSkinSDK/Widgets/OOOoyalaTVBottomBars.h
@@ -10,7 +10,8 @@
 
 @interface OOOoyalaTVBottomBars : UIView
 
-- (id)initWithBackground:(UIView *)background;
+- (id)initWithBackground:(UIView *)background
+           withTintColor:(UIColor *)tintColor;
 - (void)updateBarBuffer:(CGFloat)bufferTime
                playhead:(CGFloat)playheadTime
                duration:(CGFloat)duration

--- a/sdk/tvOS/OoyalaTVSkinSDK/Widgets/OOOoyalaTVBottomBars.h
+++ b/sdk/tvOS/OoyalaTVSkinSDK/Widgets/OOOoyalaTVBottomBars.h
@@ -11,7 +11,8 @@
 @interface OOOoyalaTVBottomBars : UIView
 
 - (instancetype)initWithBackground:(UIView *)background
-           withTintColor:(UIColor *)tintColor;
+                     withTintColor:(UIColor *)tintColor;
+
 - (void)updateBarBuffer:(CGFloat)bufferTime
                playhead:(CGFloat)playheadTime
                duration:(CGFloat)duration

--- a/sdk/tvOS/OoyalaTVSkinSDK/Widgets/OOOoyalaTVBottomBars.h
+++ b/sdk/tvOS/OoyalaTVSkinSDK/Widgets/OOOoyalaTVBottomBars.h
@@ -10,7 +10,7 @@
 
 @interface OOOoyalaTVBottomBars : UIView
 
-- (id)initWithBackground:(UIView *)background
+- (instancetype)initWithBackground:(UIView *)background
            withTintColor:(UIColor *)tintColor;
 - (void)updateBarBuffer:(CGFloat)bufferTime
                playhead:(CGFloat)playheadTime

--- a/sdk/tvOS/OoyalaTVSkinSDK/Widgets/OOOoyalaTVBottomBars.m
+++ b/sdk/tvOS/OoyalaTVSkinSDK/Widgets/OOOoyalaTVBottomBars.m
@@ -21,7 +21,7 @@
 
 @implementation OOOoyalaTVBottomBars
 
-- (id)initWithBackground:(UIView *)background {
+- (id)initWithBackground:(UIView *)background withTintColor:(UIColor *)tintColor {
   self = [super init];
   
   if (self) {
@@ -31,10 +31,7 @@
                                                                              blue:153.0/255.0
                                                                             alpha:0.3]];
     self.progressBar = [[OOOoyalaTVBar alloc] initWithFrame:CGRectMake(barX, background.bounds.size.height - bottomDistance - barHeight, 0, barHeight)
-                                                      color:[UIColor colorWithRed:68.0/255.0
-                                                                            green:138.0/255.0
-                                                                             blue:225.0/255.0
-                                                                            alpha:1.0]];
+                                                      color:tintColor];
     self.bufferBar = [[OOOoyalaTVBar alloc] initWithFrame:CGRectMake(barX, background.bounds.size.height - bottomDistance - barHeight, 0, barHeight)
                                                     color:[UIColor colorWithRed:179.0/255.0
                                                                           green:179.0/255.0

--- a/sdk/tvOS/OoyalaTVSkinSDK/Widgets/OOOoyalaTVBottomBars.m
+++ b/sdk/tvOS/OoyalaTVSkinSDK/Widgets/OOOoyalaTVBottomBars.m
@@ -21,7 +21,7 @@
 
 @implementation OOOoyalaTVBottomBars
 
-- (id)initWithBackground:(UIView *)background withTintColor:(UIColor *)tintColor {
+- (instancetype)initWithBackground:(UIView *)background withTintColor:(UIColor *)tintColor {
   self = [super init];
   
   if (self) {


### PR DESCRIPTION
This change adds a `progressTintColor` property to `OOOoyalaTVPlayerViewController`. Currently, the only mechanism to customize the PlayerViewController on tvOS is to build the view from the ground-up. Providing this optional tint color would be a quick and easy way to provide a small (but useful) amount of customization to a `OOOoyalaTVPlayerViewController`.