### PR TITLE
[PLAYER-2203] Fixed split screen fullscreen button switch

### DIFF
--- a/sdk/android/skin/src/main/java/com/ooyala/android/skin/OoyalaSkinLayout.java
+++ b/sdk/android/skin/src/main/java/com/ooyala/android/skin/OoyalaSkinLayout.java
@@ -22,11 +22,14 @@ public class OoyalaSkinLayout extends FrameLayout implements View.OnSystemUiVisi
 
   private WindowManager windowManager;
   private boolean fullscreen = false;
+  private boolean multiWindowMode = false;
 
   private int sourceWidth, sourceHeight;
 
   public interface FrameChangeCallback {
     void onFrameChangeCallback(int width, int height, int prevWidth, int prevHeight);
+
+    void onFullscreenToggleCallback();
   }
   public void setFrameChangeCallback(FrameChangeCallback fcCallback){
     this.frameChangeCallback = fcCallback;
@@ -168,6 +171,22 @@ public class OoyalaSkinLayout extends FrameLayout implements View.OnSystemUiVisi
     }
     this.fullscreen = fullscreen;
     toggleSystemUI(fullscreen);
+
+    if (multiWindowMode) {
+      // In multiWindowMode toggleSystemUI not always calls onSizeChanged,
+      // this method was created only to toggle fullscreen button on React.
+      // It helps to show current button state and keeps the states synchronized
+      // on orientation changes.
+      try {
+        this.frameChangeCallback.onFullscreenToggleCallback();
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+    }
+  }
+
+  void setMultiWindowMode(boolean multiWindowMode){
+    this.multiWindowMode = multiWindowMode;
   }
 
   private void updateLayoutSize() {

--- a/sdk/android/skin/src/main/java/com/ooyala/android/skin/OoyalaSkinLayoutController.java
+++ b/sdk/android/skin/src/main/java/com/ooyala/android/skin/OoyalaSkinLayoutController.java
@@ -7,6 +7,7 @@ import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.graphics.Color;
 import android.media.AudioManager;
+import android.os.Build;
 import android.util.DisplayMetrics;
 import android.util.Pair;
 import android.view.KeyEvent;
@@ -330,7 +331,12 @@ public class OoyalaSkinLayoutController extends Observable implements LayoutCont
         _player.setVRMode(VrMode.MONO);
       }
     }
-
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+      final Activity activity = getActivity();
+      if (activity != null) {
+        _layout.setMultiWindowMode(activity.isInMultiWindowMode());
+      }
+    }
     _layout.setFullscreen(isFullscreen);
     sendNotification(FULLSCREEN_CHANGED_NOTIFICATION_NAME, isFullscreen);
   }
@@ -584,6 +590,14 @@ public class OoyalaSkinLayoutController extends Observable implements LayoutCont
     params.putBoolean("fullscreen", isFullscreen());
 
     sendEvent("frameChanged", params);
+  }
+
+  @Override
+  public void onFullscreenToggleCallback() {
+    WritableMap params = Arguments.createMap();
+    params.putBoolean("fullscreen", isFullscreen());
+
+    sendEvent("fullscreenToggled", params);
   }
 
   public void sendEvent(String event, WritableMap map) {

--- a/sdk/react/ooyalaSkinBridgeListener.js
+++ b/sdk/react/ooyalaSkinBridgeListener.js
@@ -27,6 +27,7 @@ OoyalaSkinBridgeListener.prototype.mount = function(eventEmitter) {
     [ 'ccStylingChanged',         (event) => this.onCcStylingChange(event) ],
     [ 'currentItemChanged',       (event) => this.onCurrentItemChange(event) ],
     [ 'frameChanged',             (event) => this.onFrameChange(event) ],
+    [ 'fullscreenToggled',        (event) => this.onFullscreenToggle(event) ],
     [ 'volumeChanged',            (event) => this.onVolumeChanged(event) ],
     [ 'playCompleted',            (event) => this.onPlayComplete(event) ],
     [ 'stateChanged',             (event) => this.onStateChange(event) ],
@@ -206,6 +207,13 @@ OoyalaSkinBridgeListener.prototype.onFrameChange = function(e) {
   this.skin.setState({
     width: e.width,
     height: e.height,
+    fullscreen: e.fullscreen
+  });
+};
+
+OoyalaSkinBridgeListener.prototype.onFullscreenToggle = function(e) {
+  Log.log("Received fullscreenToggle: " + e.fullscreen);
+  this.skin.setState({
     fullscreen: e.fullscreen
   });
 };


### PR DESCRIPTION
In multiWindowMode when we try to change systemUiVisibility not always this method works. Lower window in vertical orientation can't gain access to statusbar.
But anyway we need to show current state of fullscreen button icon because you can rotate the phone in split-screen mode and icons must be the same in both orientations.
So new callback was created only to change icon in react in multiWindowMode.