### PR TITLE
[PLAYER-4907] Applyed workaround for audio only panels flicker contunously

### DIFF
--- a/sdk/react/ooyalaSkinPanelRenderer.js
+++ b/sdk/react/ooyalaSkinPanelRenderer.js
@@ -297,6 +297,7 @@ OoyalaSkinPanelRenderer.prototype.renderVolumePanel = function() {
       onDismiss={()=>this.core.dismissOverlay()}
       volume={this.skin.state.volume}
       width={this.skin.state.width}
+      height={this.skin.state.height}
       config={{
         controlBar: this.skin.props.controlBar,
         icons: this.skin.props.icons

--- a/sdk/react/panels/MoreOptionScreen.js
+++ b/sdk/react/panels/MoreOptionScreen.js
@@ -225,7 +225,7 @@ class MoreOptionScreen extends React.Component {
     );
     const animationStyle = {opacity:this.state.opacity};
     const moreOptionScreen = (
-      <Animated.View style={[styles.fullscreenContainer, animationStyle]}>
+      <Animated.View style={[styles.fullscreenContainer, animationStyle, {height: this.props.height, width: this.props.width}]}>
         <Animated.View style={[styles.rowsContainer, animationStyle]}>
           {moreOptionRow}
         </Animated.View>

--- a/sdk/react/panels/PlaybackSpeedPanel.js
+++ b/sdk/react/panels/PlaybackSpeedPanel.js
@@ -169,7 +169,7 @@ class PlaybackSpeedPanel extends React.Component {
     const animationStyle = {opacity:this.state.opacity};
 
     return (
-      <Animated.View style={[styles.panelContainer, styles.panel, animationStyle]}>
+      <Animated.View style={[styles.panelContainer, styles.panel, animationStyle, {height: this.props.height, width: this.props.width}]}>
         {this.renderHeaderView()}
         {this.renderPanelsContainerView()}
       </Animated.View>

--- a/sdk/react/panels/VolumePanel.js
+++ b/sdk/react/panels/VolumePanel.js
@@ -28,6 +28,7 @@ class VolumePanel extends React.Component {
     onVolumeChanged: PropTypes.func.isRequired,
     volume: PropTypes.number.isRequired,
     width: PropTypes.number.isRequired,
+    height: PropTypes.number.isRequired,
     config: PropTypes.object,
   };
 
@@ -213,7 +214,7 @@ class VolumePanel extends React.Component {
     const animationStyle = {opacity: this.state.opacity};
 
     return (
-      <Animated.View style={[styles.container, animationStyle]}>
+      <Animated.View style={[styles.container, animationStyle, {height: this.props.height, width: this.props.width}]}>
         {this._renderDismissButton()}
         {this._renderVolumeIcon()}
         {this._renderVolumeSlider(this.state.volume)}

--- a/sdk/react/panels/audioView.js
+++ b/sdk/react/panels/audioView.js
@@ -477,7 +477,7 @@ class AudioView extends React.Component {
 
   render() {
     return (
-      <View style={styles.backgroundView}>
+      <View style={[styles.backgroundView, {height: this.props.height, width: this.props.width}]}>
         {this._renderPlayer()}
       </View>
     )

--- a/sdk/react/panels/style/PlaybackSpeedPanelStyles.json
+++ b/sdk/react/panels/style/PlaybackSpeedPanelStyles.json
@@ -1,12 +1,10 @@
 {
 
   "panel": {
-    "flex": 1,
     "backgroundColor": "rgba(255, 255, 255, 0.2)"
   },
 
   "panelContainer": {
-    "flex": 1,
     "flexDirection": "column",
     "alignItems": "stretch"
   },

--- a/sdk/react/panels/style/VolumePanelStyles.json
+++ b/sdk/react/panels/style/VolumePanelStyles.json
@@ -1,6 +1,5 @@
 {
   "container": {
-    "flex": 1,
     "flexDirection": "row",
     "alignItems": "center",
     "justifyContent": "flex-start",

--- a/sdk/react/panels/style/audioViewStyles.json
+++ b/sdk/react/panels/style/audioViewStyles.json
@@ -1,7 +1,6 @@
 {
 
   "backgroundView": {
-    "flex": 1,
     "flexDirection": "row",
     "alignItems": "center",
     "backgroundColor": "transparent",

--- a/sdk/react/panels/style/moreOptionScreenStyles.json
+++ b/sdk/react/panels/style/moreOptionScreenStyles.json
@@ -1,6 +1,5 @@
 {
   "fullscreenContainer": {
-    "flex": 1,
     "flexDirection": "column",
     "backgroundColor": "rgba(0, 0, 0, 0.8)"
   },


### PR DESCRIPTION
There is a bug in React native realization https://github.com/wix/react-native-navigation/issues/2138
Until it will be fixed , we can applying workaround :
Don't use  flex:1 in style of root view and add Width and Height in a style of that view.