### PR TITLE
[PLAYER-4914] Removed unused switch handling

### DIFF
--- a/sdk/iOS/OoyalaSkinSDK/React/OOReactSkinEventsEmitter.m
+++ b/sdk/iOS/OoyalaSkinSDK/React/OOReactSkinEventsEmitter.m
@@ -41,6 +41,7 @@ RCT_EXPORT_MODULE(OOReactSkinEventsEmitter);
            @"ccStylingChanged",
            @"currentItemChanged",
            @"frameChanged",
+           @"fullscreenToggled",
            @"volumeChanged",
            @"playCompleted",
            @"stateChanged",

--- a/sdk/react/ooyalaSkinCore.js
+++ b/sdk/react/ooyalaSkinCore.js
@@ -134,12 +134,6 @@ OoyalaSkinCore.prototype.handlePress = function(buttonName) {
     case BUTTON_NAMES.QUALITY:
     case BUTTON_NAMES.SETTING:
       break;
-    case BUTTON_NAMES.REPLAY:
-      this.skin.setState({
-        onPlayComplete: false
-      });
-      this.bridge.onPress({name: buttonName});
-      break;
     case BUTTON_NAMES.VOLUME:
       this.pushToOverlayStackAndMaybePause(OVERLAY_TYPES.VOLUME_SCREEN);
       break;


### PR DESCRIPTION
- added `fullscreenToggled` to supported methods to avoid a red screen
- removed unused switch handling for `replay` button