### PR TITLE
[PLAYER-3881] "Off" is not highlighted in CC list if it doesn't contain same language as was selected in previous video

### DIFF
--- a/sdk/react/panels/AudioAndCCSelectionPanel.js
+++ b/sdk/react/panels/AudioAndCCSelectionPanel.js
@@ -180,7 +180,7 @@ class AudioAndCCSelectionPanel extends React.Component {
       }
     }
 
-    if (!selectedClosedCaptionsLanguage || selectedClosedCaptionsLanguage === offButtonTitle || selectedClosedCaptionsLanguage === "") {
+    if (!selectedClosedCaptionsLanguage || selectedClosedCaptionsLanguage === offButtonTitle || selectedClosedCaptionsLanguage === "" || !this.props.closedCaptionsLanguages.includes(selectedClosedCaptionsLanguage, 0)) {
       selectedClosedCaptionsLanguage = offButtonTitle;
     }
 


### PR DESCRIPTION
CC: set selected CC language as “off”, if the language selected previously is not included in the list of available CC for the current video.