### PR TITLE
[PLAYER-4945] Changes in resizable player update logic

### DIFF
--- a/sdk/android/skin/src/main/java/com/ooyala/android/skin/OoyalaSkinLayout.java
+++ b/sdk/android/skin/src/main/java/com/ooyala/android/skin/OoyalaSkinLayout.java
@@ -4,6 +4,7 @@ package com.ooyala.android.skin;
 import android.app.Activity;
 import android.content.Context;
 import android.content.res.Configuration;
+import android.content.res.TypedArray;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewGroup;
@@ -25,6 +26,7 @@ public class OoyalaSkinLayout extends FrameLayout implements View.OnSystemUiVisi
   private boolean multiWindowMode = false;
 
   private int sourceWidth, sourceHeight;
+  private boolean resizableLayout;
 
   public interface FrameChangeCallback {
     void onFrameChangeCallback(int width, int height, int prevWidth, int prevHeight);
@@ -51,6 +53,14 @@ public class OoyalaSkinLayout extends FrameLayout implements View.OnSystemUiVisi
    */
   public OoyalaSkinLayout(Context context, AttributeSet attrs) {
     super(context, attrs);
+    TypedArray typedArray = context.getTheme().obtainStyledAttributes(
+            attrs,
+            R.styleable.OoyalaSkinLayout, 0, 0);
+    try {
+      resizableLayout = typedArray.getBoolean(R.styleable.OoyalaSkinLayout_resizableLayout, false);
+    } finally {
+      typedArray.recycle();
+    }
     createSubViews();
   }
 
@@ -72,7 +82,7 @@ public class OoyalaSkinLayout extends FrameLayout implements View.OnSystemUiVisi
   public void createSubViews() {
     if (playerFrame == null) {
       FrameLayout.LayoutParams frameLP =
-         new FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT);
+              new FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT);
       playerFrame = new FrameLayout(this.getContext());
       this.addView(playerFrame, frameLP);
 
@@ -132,27 +142,34 @@ public class OoyalaSkinLayout extends FrameLayout implements View.OnSystemUiVisi
     return this.fullscreen;
   }
 
+  public int getSourceWidth() {
+    return sourceWidth;
+  }
+
+  public int getSourceHeight() {
+    return sourceHeight;
+  }
 
   /**
    * Show/Hide system ui (notification and navigation bar) depending if layout is in fullscreen
    */
   public void toggleSystemUI(boolean fullscreen) {
-    if(fullscreen) {
+    if (fullscreen) {
       if (SDK_INT >= KITKAT) {
         setSystemUiVisibility(
                 View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-                | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION     // hide nav bar
-                | View.SYSTEM_UI_FLAG_FULLSCREEN          // hide status bar
-                | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);  // toggle system UI visibility automatically
+                        | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                        | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                        | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION     // hide nav bar
+                        | View.SYSTEM_UI_FLAG_FULLSCREEN          // hide status bar
+                        | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);  // toggle system UI visibility automatically
       } else {
         setSystemUiVisibility(
                 View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-                | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION     // hide nav bar
-                | View.SYSTEM_UI_FLAG_FULLSCREEN);        // hide status bar
+                        | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                        | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                        | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION     // hide nav bar
+                        | View.SYSTEM_UI_FLAG_FULLSCREEN);        // hide status bar
       }
     } else {
       setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE);
@@ -206,11 +223,15 @@ public class OoyalaSkinLayout extends FrameLayout implements View.OnSystemUiVisi
   @Override
   protected void onConfigurationChanged(Configuration newConfig) {
     super.onConfigurationChanged(newConfig);
-    updateLayoutSize();
+    if (!resizableLayout) {
+      updateLayoutSize();
+    }
   }
 
   @Override
   public void onSystemUiVisibilityChange(int i) {
-    updateLayoutSize();
+    if (!resizableLayout) {
+      updateLayoutSize();
+    }
   }
 }

--- a/sdk/android/skin/src/main/res/values/attrs.xml
+++ b/sdk/android/skin/src/main/res/values/attrs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <declare-styleable name="OoyalaSkinLayout">
+        <attr name="resizableLayout" format="boolean" />
+    </declare-styleable>
+</resources>


### PR DESCRIPTION
https://jira.corp.ooyala.com/browse/PLAYER-4945

MERGE ONLY AFTER CANDIDATE IS MERGED IN DEV

Connected with this request https://github.com/ooyala/android-sample-apps/pull/416

Here are fixed uncorrect sizes and behavior of resizable player.

There are much more conditions than were implemented in OoyalaSkinLayout, so some callbacks from there are disabled and handled by new logic.
Toolbar added to get rid of that bug
https://stackoverflow.com/questions/28874114/action-bar-displayed-incorrectly-when-returning-from-immersive-mode