### PR TITLE
[PBA-6620] - Time controlBar asset > 1hour

### DIFF
--- a/sdk/tvOS/OoyalaTVSkinSDK/UI/OOOoyalaTVPlayerViewController.m
+++ b/sdk/tvOS/OoyalaTVSkinSDK/UI/OOOoyalaTVPlayerViewController.m
@@ -249,6 +249,8 @@ static OOClosedCaptionsStyle *_closedCaptionsStyle;
 - (void)updateTimeWithDuration:(CGFloat)duration playhead:(CGFloat)playhead {
   NSDateFormatter *dateformat = [NSDateFormatter new];
   dateformat.dateFormat = duration < 3600 ? @"mm:ss" : @"H:mm:ss";
+  dateformat.locale = NSLocale.systemLocale;
+  dateformat.timeZone = [NSTimeZone timeZoneForSecondsFromGMT:0];
   self.playheadLabel.text = [NSString stringWithFormat:@"%@", [dateformat stringFromDate:[NSDate dateWithTimeIntervalSince1970:playhead]]];
   self.durationLabel.text = [NSString stringWithFormat:@"%@", [dateformat stringFromDate:[NSDate dateWithTimeIntervalSince1970:duration]]];
   


### PR DESCRIPTION
There were some display issues when asset was > 1 hour. Fix is setting timezone to asset playhead and duration to avoid bugs.

Jira ticket: https://jira.corp.ooyala.com/browse/PBA-6620