### PR TITLE
[PLAYER-5012] Made working closedCaptionOptions.backgroundOpacity property from skin.json

### DIFF
--- a/sdk/react/ooyalaSkinPanelRenderer.js
+++ b/sdk/react/ooyalaSkinPanelRenderer.js
@@ -192,7 +192,8 @@ OoyalaSkinPanelRenderer.prototype.renderVideoView = function() {
         icons: this.skin.props.icons,
         adScreen: this.skin.props.adScreen,
         live: this.skin.props.live,
-        skipControls: this.skin.props.skipControls
+        skipControls: this.skin.props.skipControls,
+        ccBackgroundOpacity: this.skin.props.closedCaptionOptions.backgroundOpacity
       }}
       nextVideo={this.skin.state.nextVideo}
       upNextDismissed={this.skin.state.upNextDismissed}

--- a/sdk/react/panels/style/panelStyles.json
+++ b/sdk/react/panels/style/panelStyles.json
@@ -45,8 +45,7 @@
   "closedCaptions": {
     "alignSelf": "center",
     "textAlign": "center",
-    "padding": 2,
-    "margin": 2,
+    "padding": 4,
     "fontWeight": "bold",
     "fontSize": 16,
     "fontFamily": "Helvetica",

--- a/sdk/react/panels/videoView.js
+++ b/sdk/react/panels/videoView.js
@@ -231,21 +231,18 @@ class VideoView extends React.Component {
 
     const ccStyle = {
       color: this.props.captionStyles.textColor, fontFamily: this.props.captionStyles.fontName,
-      backgroundColor: this.props.captionStyles.textBackgroundColor
+      backgroundColor: 'rgba(0,0,0,'+this.props.config.ccBackgroundOpacity+')'
     };
     if (this.props.caption) {
       return (
         <View
           accessible={false}
           importantForAccessibility="no-hide-descendants"
-          style={[panelStyles.closedCaptionsContainer, {padding: containerPadding, width: captionWidth}]}
+          style={[panelStyles.closedCaptionsContainer, {padding: containerPadding, width: captionWidth, backgroundColor: 'transparent'}]}
           onTouchEnd={(event) => this.props.handlers.handleVideoTouchEnd(event)}>
-          <View
-            style={[{backgroundColor: this.props.captionStyles.backgroundColor}]}>
-            <Text style={[panelStyles.closedCaptions, ccStyle]}>
-              {this.props.caption}
-            </Text>
-          </View>
+          <Text style={[panelStyles.closedCaptions, ccStyle]}>
+            {this.props.caption}
+          </Text>
         </View>
       );
     }


### PR DESCRIPTION
There is backgroundOpacity property along with others in closedCaptionOptions section of skin.json, this fix make it working.

P.S. Looks like all others properties from that section just ignored , going to make task in JIRA for fix it.