### PR TITLE
[PBA-6620] - Time controlBar asset > 1hour

### DIFF
--- a/sdk/tvOS/OoyalaTVSkinSDK/UI/OOOoyalaTVPlayerViewController.m
+++ b/sdk/tvOS/OoyalaTVSkinSDK/UI/OOOoyalaTVPlayerViewController.m
@@ -298,8 +298,10 @@ static OOClosedCaptionsStyle *_closedCaptionsStyle;
   // That's because the initial value of lastTriggerTime is zero and for live assets that's incorrect.
   // We update lastTriggerTime when we see that the asset is live and it is exactly at 0.0.
   // 0.0 will not be reached again if skipped to the beginning because the DVR window is always sliding to the right.
-  if (self.player.currentItem.live && self.lastTriggerTime == 0.0) {
-    self.lastTriggerTime = playhead;
+  if (self.player.currentItem.live) {
+    self.lastTriggerTime = self.lastTriggerTime == 0 ? playhead : self.lastTriggerTime;
+    self.playheadLabel.text = nil;
+    self.durationLabel.text = @"LIVE";
   }
   
   if (playhead - self.lastTriggerTime > hideBarInterval &&
@@ -496,10 +498,18 @@ static OOClosedCaptionsStyle *_closedCaptionsStyle;
     bufferedTime = 0;
   }
   
-  [self.bottomBars updateBarBuffer:bufferedTime
-                          playhead:playhead
-                          duration:self.player.duration
-                       totalLength:self.progressBarBackground.bounds.size.width - barX - headDistance - labelWidth - componentSpace];
+  if (self.player.currentItem.live) {
+    //Sometimes we receive bigger playhead and we want to set progress max to player duration.
+    playhead = playhead > self.player.duration ? self.player.duration : playhead;
+    [self.bottomBars updateProgressBarTime:playhead duration:self.player.duration totalLength:self.progressBarBackground.bounds.size.width - barX - headDistance - labelWidth - componentSpace];
+  } else {
+    [self.bottomBars updateBarBuffer:bufferedTime
+                            playhead:playhead
+                            duration:self.player.duration
+                         totalLength:self.progressBarBackground.bounds.size.width - barX - headDistance - labelWidth - componentSpace];
+  }
+  
+  
   
   self.gestureManager.playheadTime = playhead;
   self.gestureManager.durationTime = self.player.duration;

--- a/sdk/tvOS/OoyalaTVSkinSDK/Widgets/OOOoyalaTVBottomBars.h
+++ b/sdk/tvOS/OoyalaTVSkinSDK/Widgets/OOOoyalaTVBottomBars.h
@@ -17,4 +17,8 @@
                duration:(CGFloat)duration
             totalLength:(CGFloat)length;
 
+- (void)updateProgressBarTime:(CGFloat)time
+                   duration:(CGFloat)duration
+                totalLength:(CGFloat)length;
+
 @end

--- a/sdk/tvOS/OoyalaTVSkinSDK/Widgets/OOOoyalaTVBottomBars.m
+++ b/sdk/tvOS/OoyalaTVSkinSDK/Widgets/OOOoyalaTVBottomBars.m
@@ -86,6 +86,12 @@
   [self updateBar:self.progressBar barTime:playheadTime duration:duration totalLength:length];
 }
 
+- (void)updateProgressBarTime:(CGFloat)time
+         duration:(CGFloat)duration
+      totalLength:(CGFloat)length {
+  [self updateBar:self.progressBar barTime:time duration:duration totalLength:length];
+}
+
 #pragma mark - Private functions
 
 - (void)updateBar:(OOOoyalaTVBar *)bar


### PR DESCRIPTION
We had some issues when displaying playhead for live assets, so this PR modifies how playhead looks for live asset, adding "LIVE" label instead of actual playhead.