### PR TITLE
[PLAYER-5099] EndScreen fixed when controlBar is disabled in skin.json

### DIFF
--- a/sdk/react/panels/EndScreen.js
+++ b/sdk/react/panels/EndScreen.js
@@ -68,6 +68,10 @@ class EndScreen extends React.Component {
 
   _renderDefaultScreen = (progressBar, controlBar) => {
     const endScreenConfig = this.props.config.endScreen || {};
+
+    const replayMarginBottom = !this.props.config.controlBar.enabled ?
+      ResponsiveDesignManager.makeResponsiveMultiplier(this.props.width, UI_SIZES.CONTROLBAR_HEIGHT) : 1;
+
     const replayButtonLocation = styles.replayButtonCenter;
     let replayButton;
 
@@ -89,7 +93,7 @@ class EndScreen extends React.Component {
     const infoPanel = (<InfoPanel title={title} description={description} />);
 
     return (
-      <View style={styles.fullscreenContainer}>
+      <View style={[styles.fullscreenContainer, {width: this.props.width,height: this.props.height}]}>
         <Image
           source={{uri: this.props.promoUrl}}
           style={
@@ -102,7 +106,7 @@ class EndScreen extends React.Component {
           resizeMode={Image.resizeMode.contain}>
         </Image>
         {infoPanel}
-        <View style={replayButtonLocation}>
+        <View style={[replayButtonLocation, {marginBottom: replayMarginBottom}]}>
           {replayButton}
         </View>
         <View style={styles.controlBarPosition}>


### PR DESCRIPTION
EndScreen fixed when controlBar is disabled in skin.json

1) Fixed the size of the screen
2) Fixed the position of replay button