### PR TITLE
[Player 4762] Broken fast forwarding/rewind animation while buffering

### DIFF
--- a/sdk/tvOS/OoyalaTVSkinSDK/UI/OOOoyalaTVPlayerViewController.m
+++ b/sdk/tvOS/OoyalaTVSkinSDK/UI/OOOoyalaTVPlayerViewController.m
@@ -242,55 +242,41 @@ static OOClosedCaptionsStyle *_closedCaptionsStyle;
 - (void)bufferingStartedNotification {
   [self startActivityIndicator];
   self.bufferingAsked = YES;
-  NSLog(@"bufferingStartedNotification. activity LAUNCHED ✅ lifecycle, step 3");
 }
 
 - (void)bufferingCompletedNotification {
   [self stopActivityIndicator];
   self.bufferingAsked = NO;
-  NSLog(@"bufferingCompletedNotification. activity STOPPED ✅ lifecycle, step 4");
 }
 
 - (void)seekStartedNotification {
   [self startActivityIndicator];
-  NSLog(@"seekStartedNotification. activity LAUNCHED ⚠️ lifecycle, step 1");
 }
 
-- (void)seekCompletedNotification {
-  //[self stopActivityIndicator]; //absolutly haven't be used, because picture is frozen umtil [Playing] occurs
-  NSLog(@"seekCompletedNotification.⚠️ lifecycle, step 2");
-}
+- (void)seekCompletedNotification { }
 
 - (void)stateChangedNotification {
-  NSLog(@"⚠️ - stateChangedNotification. state: [%d]", self.player.state);
+  
   dispatch_async(dispatch_get_main_queue(), ^{
     switch (self.player.state) {
-      case OOOoyalaPlayerStateLoading: //1
-        NSLog(@"OOOoyalaPlayerStateLoading. activity LAUNCHED");
+      case OOOoyalaPlayerStateLoading:
         [self startActivityIndicator];
         break;
-      case OOOoyalaPlayerStatePaused: //4
+      case OOOoyalaPlayerStatePaused:
         break;
-      case OOOoyalaPlayerStateCompleted: //5
-        NSLog(@"OOOoyalaPlayerStateCompleted");
+      case OOOoyalaPlayerStateCompleted:
         [self.playPauseButton changePlayingState:self.player.isPlaying];
         break;
-      case OOOoyalaPlayerStateReady: //2
+      case OOOoyalaPlayerStateReady:
         break;
-      case OOOoyalaPlayerStatePlaying: //3
-        NSLog(@"✅ OOOoyalaPlayerStatePlaying - activity not changed");
+      case OOOoyalaPlayerStatePlaying:
         if (!self.isBufferingAsked) {
           [self stopActivityIndicator];
         }
         break;
-      case OOOoyalaPlayerStateError: //6
-        NSLog(@"❌  OOOoyalaPlayerStateError");
-        [self stopActivityIndicator];
-        break;
+      case OOOoyalaPlayerStateError:
       default:
-        NSLog(@"⚠️ [default]");
         [self stopActivityIndicator];
-        break;
     }
     [self showClosedCaptionsButton];
   });

--- a/sdk/tvOS/OoyalaTVSkinSDK/UI/OOOoyalaTVPlayerViewController.m
+++ b/sdk/tvOS/OoyalaTVSkinSDK/UI/OOOoyalaTVPlayerViewController.m
@@ -238,35 +238,52 @@ static OOClosedCaptionsStyle *_closedCaptionsStyle;
 
 - (void)bufferingStartedNotification {
   [self startActivityIndicator];
+  NSLog(@"✅  bufferingStartedNotification. activity LAUNCHED");
 }
 
 - (void)bufferingCompletedNotification {
   [self stopActivityIndicator];
+  NSLog(@"✅ bufferingCompletedNotification. activity STOPPED");
+  //NSLog(@"✅ bufferingCompletedNotification.");
 }
 
 - (void)seekStartedNotification {
   [self startActivityIndicator];
+  NSLog(@"✅ seekStartedNotification. activity LAUNCHED");
 }
 
 - (void)seekCompletedNotification {
-  [self stopActivityIndicator];
+  //[self stopActivityIndicator];
+  //NSLog(@"✅ seekCompletedNotification. activity STOPPED");
+  NSLog(@"✅ seekCompletedNotification.");
 }
 
 - (void)stateChangedNotification {
+  NSLog(@"✅ - stateChangedNotification. state: [%d]", self.player.state);
   dispatch_async(dispatch_get_main_queue(), ^{
     switch (self.player.state) {
-      case OOOoyalaPlayerStateLoading:
+      case OOOoyalaPlayerStateLoading: //1
+        NSLog(@"OOOoyalaPlayerStateLoading. activity LAUNCHED");
         [self startActivityIndicator];
         break;
-      case OOOoyalaPlayerStatePaused:
+      case OOOoyalaPlayerStatePaused: //4
         break;
-      case OOOoyalaPlayerStateCompleted:
+      case OOOoyalaPlayerStateCompleted: //5
+        NSLog(@"OOOoyalaPlayerStateCompleted");
         [self.playPauseButton changePlayingState:self.player.isPlaying];
-      case OOOoyalaPlayerStateReady:
-      case OOOoyalaPlayerStatePlaying:
-      case OOOoyalaPlayerStateError:
+        break;
+      case OOOoyalaPlayerStateReady: //2
+        break;
+      case OOOoyalaPlayerStatePlaying: //3
+        //[self stopActivityIndicator];
+        break;
+      case OOOoyalaPlayerStateError: //6
+        NSLog(@"❌  OOOoyalaPlayerStateError");
+        break;
       default:
-        [self stopActivityIndicator];
+        NSLog(@"[default]");
+        //[self stopActivityIndicator];
+        break;
     }
     [self showClosedCaptionsButton];
   });


### PR DESCRIPTION
Problem: Animation for activity indicator doesn't appear while video is buffering.
Problem occurs because notification for player's state `OOOoyalaPlayerStatePlaying` arrives to early, while buffering hasn't finished and playing is not started. 

The activity must be stopped in two cases: after fast-forward rewinding  and after player's initial launching.
To resolve problem in first case activity  is stopped when notification `OOOoyalaPlayerBufferingCompletedNotification` arrives. 
To handle second case when activity must be stopped after player's initial launching, was added flag that indicates if class is waiting for BufferingCompleted event 

Unit tests not included.