### PR TITLE
[PLAYER-5079] No response when clicked on the Up-Next pop up]

### DIFF
--- a/sdk/iOS/OoyalaSkinSDK/OOUpNextManager.m
+++ b/sdk/iOS/OoyalaSkinSDK/OOUpNextManager.m
@@ -15,7 +15,7 @@
 @property (nonatomic, weak) OOReactSkinModel *ooReactSkinModel;
 @property (nonatomic) BOOL upNextEnabled;
 @property (nonatomic) BOOL isDismissed;
-@property (nonatomic, weak) NSDictionary *nextVideo;
+@property (nonatomic) NSDictionary *nextVideo;
 
 @end
 


### PR DESCRIPTION
When command **play next video** arrives there is a checking in class `OOUpNextManager` and video can be played only if true `if (!self.isDismissed && self.nextVideo)` 
But dictionary with the next video was attached to manager by weak reference, so every time checking `self.nextVideo` was failed.
Changed reference from weak (I hope it's was typo) to strong, because NSDictionary doesn't possess reverse reference to `OOUpNextManager`, so retain cycle is impossible in this case.
@maxkupetskii  Please, check if assigning weak reference in commit #[8fa02ca7] on 18 Jan 2019 was a typo.