### PR TITLE
[PLAYER-4927] Removed unnecessary accessibility labels for progress bar

### DIFF
--- a/sdk/react/bottomOverlay.js
+++ b/sdk/react/bottomOverlay.js
@@ -161,7 +161,7 @@ const BottomOverlay = createReactClass({
         testID={VIEW_NAMES.TIME_SEEK_BAR_THUMB}
         accessible={false}
         importantForAccessibility="no-hide-descendants"
-        accessibilityLabel={VIEW_NAMES.TIME_SEEK_BAR_THUMB}
+        accessibilityLabel=""
         style={[scrubberStyle, positionStyle, {width:scrubberSize, height:scrubberSize}]}>
       </View>
       );

--- a/sdk/react/common/progressBar.js
+++ b/sdk/react/common/progressBar.js
@@ -72,19 +72,19 @@ class ProgressBar extends React.Component {
         style={styles.container}
         testID={VIEW_NAMES.TIME_SEEK_BAR}
         importantForAccessibility="no-hide-descendants"
-        accessibilityLabel={VIEW_NAMES.TIME_SEEK_BAR}>
+        accessibilityLabel="">
           <View
             style={progressStyles.played}
             testID={VIEW_NAMES.TIME_SEEK_BAR_PLAYED}
-            accessibilityLabel={VIEW_NAMES.TIME_SEEK_BAR_PLAYED}/>
+            accessibilityLabel=""/>
           <View
             style={progressStyles.background}
             testId={VIEW_NAMES.TIME_SEEK_BAR_BACKGROUND}
-            accessibilityLabel={VIEW_NAMES.TIME_SEEK_BAR_BACKGROUND}/>
+            accessibilityLabel=""/>
           <View
             style={progressStyles.buffered}
             testID={VIEW_NAMES.TIME_SEEK_BAR_BUFFERED}
-            accessibilityLabel={VIEW_NAMES.TIME_SEEK_BAR_BUFFERED}/>
+            accessibilityLabel=""/>
       </View>
     );
   }


### PR DESCRIPTION
For TalkBack feature we are using scrubberBarAccessibilityLabel for our progress bar.
In spite of using "importantForAccessibility="no-hide-descendants" and accessible={false} some of parts (views) our custom progress bar  force TalkBack  to voice unintended text  on some specific android devices. So i propose remove these accessibility labels :
'seekBar', 'seekBar_thumb', 'seekBar_played', 'seekBar_background', 'seekBar_buffered' 
