### PR TITLE
[PLAYER-5273] ExoPlayer ver is changed to 2.9.3 due to HLS multi audio errors

### DIFF
--- a/sdk/android/build.gradle
+++ b/sdk/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         javaVersion = JavaVersion.VERSION_1_8
 
         // App dependencies
-        exoplayerVersion = '2.9.5'
+        exoplayerVersion = '2.9.3'
         gsonVersion = '2.8.5'
         hamcrestVersion = '1.3'
         injectVersion = '1'


### PR DESCRIPTION
Multiple Audio tracks are not displayed for selection for some of HLS MultiAudio assets.
The issue is not seen with ExoPlayer ver 2.9.3. Since 2.9.3 the issue is reproducible in ExoPlayer demo and in our codebase.
I'll create a ticket in ExoPlayer GitHub to track the issue.