### PR TITLE
[PBA-6691] Removed unnecessary localization convertions for audio track titles

### DIFF
--- a/sdk/react/panels/AudioAndCCSelectionPanel.js
+++ b/sdk/react/panels/AudioAndCCSelectionPanel.js
@@ -20,6 +20,7 @@ import {
 } from '../constants';
 
 const Utils = require('../utils');
+const Log = require('../log');
 const styles = require('../utils').getStyles(require('./style/AudioAndCCSelectionPanel'));
 const ItemSelectionScrollView = require('./ItemSelectionScrollView');
 
@@ -66,15 +67,8 @@ class AudioAndCCSelectionPanel extends React.Component {
 
 
   onAudioTrackSelected = (name) => {
-    const localizedTitleForUndefinedLanguage = Utils.localizedString(this.props.config.locale, stringConstants.undefinedLanguageTitle, this.props.config.localizableStrings);
-    const localizedTitleForNoLinguisticContent = Utils.localizedString(this.props.config.locale, stringConstants.noLinguisticContentTitle, this.props.config.localizableStrings);
-    let originalName = name;
-
-    originalName = originalName.replace(localizedTitleForUndefinedLanguage, stringConstants.undefinedLanguageTitle);
-    originalName = originalName.replace(localizedTitleForNoLinguisticContent, stringConstants.noLinguisticContentTitle);
-
-    if (this.props.selectedAudioTrackTitle !== originalName) {
-      this.props.onSelectAudioTrack(originalName);
+    if (this.props.selectedAudioTrackTitle !== name) {
+      this.props.onSelectAudioTrack(name);
     }
   };
 
@@ -137,33 +131,11 @@ class AudioAndCCSelectionPanel extends React.Component {
   };
 
   renderAudioSelectionScrollView = () => {
-    const localizedTitleForUndefinedLanguage = Utils.localizedString(this.props.config.locale, stringConstants.undefinedLanguageTitle, this.props.config.localizableStrings);
-    const localizedTitleForNoLinguisticContent = Utils.localizedString(this.props.config.locale, stringConstants.noLinguisticContentTitle, this.props.config.localizableStrings);
-
-    // Localize selected item
-
-    let selectedLocalizedItem = this.props.selectedAudioTrackTitle;
-    if (selectedLocalizedItem !== undefined) {
-      selectedLocalizedItem = selectedLocalizedItem.replace(stringConstants.undefinedLanguageTitle, localizedTitleForUndefinedLanguage);
-      selectedLocalizedItem = selectedLocalizedItem.replace(stringConstants.noLinguisticContentTitle, localizedTitleForNoLinguisticContent);
-    }
-
-    // Localize other items
-
-    const itemsWithLocalizedUndefinedLanguage = this.props.audioTracksTitles.map(function(item) {
-      let localizedItem = item;
-
-      localizedItem = localizedItem.replace(stringConstants.undefinedLanguageTitle, localizedTitleForUndefinedLanguage);
-      localizedItem = localizedItem.replace(stringConstants.noLinguisticContentTitle, localizedTitleForNoLinguisticContent);
-
-      return localizedItem;
-    });
-
     return (
       <ItemSelectionScrollView
         style={styles.panelItemSelectionView}
-        items={itemsWithLocalizedUndefinedLanguage}
-        selectedItem={selectedLocalizedItem}
+        items={this.props.audioTracksTitles}
+        selectedItem={this.props.selectedAudioTrackTitle}
         onSelect={(item) => this.onAudioTrackSelected(item)}
         config={this.props.config}
         cellType={CELL_TYPES.MULTI_AUDIO}>

--- a/sdk/react/panels/AudioAndCCSelectionPanel.js
+++ b/sdk/react/panels/AudioAndCCSelectionPanel.js
@@ -20,7 +20,6 @@ import {
 } from '../constants';
 
 const Utils = require('../utils');
-const Log = require('../log');
 const styles = require('../utils').getStyles(require('./style/AudioAndCCSelectionPanel'));
 const ItemSelectionScrollView = require('./ItemSelectionScrollView');
 


### PR DESCRIPTION
We don't need localization conversion from current locale to english for undefinedLanguageTitle and for noLinguisticContentTitle , SDK wait them in current locale (at least Android SDK) , need to check it on iOS