### PR TITLE
[PLAYER-5409] Enable OpenMeasurement in Google IMA SDKs

### DIFF
--- a/sdk/android/skin/src/main/java/com/ooyala/android/skin/OoyalaSkinLayoutController.java
+++ b/sdk/android/skin/src/main/java/com/ooyala/android/skin/OoyalaSkinLayoutController.java
@@ -318,6 +318,11 @@ public class OoyalaSkinLayoutController extends Observable implements LayoutCont
     return _layout.getPlayerLayout();
   }
 
+  @Override
+  public FrameLayout getControlLayout() {
+    return rootView;
+  }
+
   public float getCurrentVolume() {
     AudioManager audioManager = (AudioManager) _layout.getContext().getSystemService(Context.AUDIO_SERVICE);
     return (float)audioManager.getStreamVolume(AudioManager.STREAM_MUSIC)/(float)audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC);


### PR DESCRIPTION
Implement a new method getControlLayout to enable OpenMeasurement in Google IMA SDKs.

I registered a control layout according to this short documentation: https://storage.googleapis.com/dfp-support/ocorso/2019/ima-omid/%5BEXTERNAL%5D%20OMSDK%20in%20IMA%20for%20iOS%20and%20Android.pdf

The tricky thing here is the fact that I don't know how to test it and make sure that OpenMeasurement works as expected. At least IMA Ads work as usual.