### PR TITLE
[Player 5411] Utilize new icons for PiP from Ooyala font

### DIFF
--- a/sdk/iOS/OoyalaSkinSDK/React/OOReactSkinEventsEmitter.m
+++ b/sdk/iOS/OoyalaSkinSDK/React/OOReactSkinEventsEmitter.m
@@ -69,8 +69,7 @@ RCT_EXPORT_MODULE(OOReactSkinEventsEmitter);
            @"audioTrackChanged",
            @"playbackSpeedEnabled",
            @"playbackSpeedRateChanged",
-           @"castDevicesAvailable"
-           ];
+           @"castDevicesAvailable"];
 }
 
 - (void)sendDeviceEventWithName:(NSString *)eventName body:(id)body {

--- a/sdk/iOS/OoyalaSkinSDK/React/OOReactSkinEventsEmitter.m
+++ b/sdk/iOS/OoyalaSkinSDK/React/OOReactSkinEventsEmitter.m
@@ -69,11 +69,7 @@ RCT_EXPORT_MODULE(OOReactSkinEventsEmitter);
            @"audioTrackChanged",
            @"playbackSpeedEnabled",
            @"playbackSpeedRateChanged",
-           @"castDevicesAvailable",
-           
-           @"castConnected",
-           @"castDisconnected",
-           @"castConnecting"
+           @"castDevicesAvailable"
            ];
 }
 

--- a/sdk/iOS/OoyalaSkinSDK/React/OOReactSkinEventsEmitter.m
+++ b/sdk/iOS/OoyalaSkinSDK/React/OOReactSkinEventsEmitter.m
@@ -69,7 +69,12 @@ RCT_EXPORT_MODULE(OOReactSkinEventsEmitter);
            @"audioTrackChanged",
            @"playbackSpeedEnabled",
            @"playbackSpeedRateChanged",
-           @"castDevicesAvailable"];
+           @"castDevicesAvailable",
+           
+           @"castConnected",
+           @"castDisconnected",
+           @"castConnecting"
+           ];
 }
 
 - (void)sendDeviceEventWithName:(NSString *)eventName body:(id)body {

--- a/sdk/react/controlBar.js
+++ b/sdk/react/controlBar.js
@@ -208,7 +208,7 @@ class ControlBar extends Component {
         onPress: this.onPipButtonPress,
         iconTouchableStyle: styles.iconTouchable,
         style: [styles.icon, { fontSize: iconFontSize }, config.controlBar.iconStyle.active],
-        icon: this.props.isPipActivated ? config.icons.volumeOff : config.icons.replay, // OS: name in your project skin.json -> 'icons'. Should be replaced on feature-specific icons
+        icon: this.props.isPipActivated ? config.icons.pipInButton : config.icons.pipOutButton,
         isActive: this.props.isPipActivated,
         enabled: this.props.isPipButtonVisible,
       },


### PR DESCRIPTION
**Ticket goal:** Utilize new icons for PiP from Ooyala font
**How PR achieves the goal:** ControllBar.js uses proper PIP-specific icons that configured in Skin.json in `vendor/Ooyala/OoyalaSkinSDK-iOS/skin-config/skin.json`
**Notes:** This PR works with appropriate changes in SampleApp.

**Unit tests:** Unit tests were not added, because changes performed in JS-part. @loginov-rocks  please, take a look.