### PR TITLE
[PLAYER-5424] Implemented setRootRecyclerView and getTagsForScrollabl…

### DIFF
--- a/sdk/android/skin/src/main/java/com/ooyala/android/skin/OoyalaSkinLayoutController.java
+++ b/sdk/android/skin/src/main/java/com/ooyala/android/skin/OoyalaSkinLayoutController.java
@@ -111,7 +111,6 @@ public class OoyalaSkinLayoutController extends Observable implements LayoutCont
   private boolean isReactMounted;
   private boolean isTargetTV;
   private RecyclerView rootRecyclerView = null;
-  private View.OnLayoutChangeListener recyclerLayoutChangeListener = null;
 
   /**
    * Create the OoyalaSkinLayoutController, which is the core unit of the Ooyala Skin Integration
@@ -537,6 +536,9 @@ public class OoyalaSkinLayoutController extends Observable implements LayoutCont
     if (rootRecyclerView == null) {
       return;
     }
+    if (getTagsForScrollableViews() == null) {
+      return;
+    }
     for (String tag: getTagsForScrollableViews()) {
       View scrollableView = rootRecyclerView.findViewWithTag(tag);
       if (scrollableView != null) {
@@ -551,7 +553,6 @@ public class OoyalaSkinLayoutController extends Observable implements LayoutCont
             view.performClick();
           }
           return false;
-
         });
       }
     }
@@ -559,13 +560,11 @@ public class OoyalaSkinLayoutController extends Observable implements LayoutCont
 
   @Override
   public void setRootRecyclerView(RecyclerView recyclerView) {
-
     if (recyclerView == null) {
       return;
     }
     rootRecyclerView = recyclerView;
     rootRecyclerView.addOnLayoutChangeListener(this);
-
   }
 
   @Override

--- a/sdk/android/skin/src/main/java/com/ooyala/android/skin/view/VolumeViewManager.java
+++ b/sdk/android/skin/src/main/java/com/ooyala/android/skin/view/VolumeViewManager.java
@@ -43,5 +43,6 @@ public class VolumeViewManager extends SimpleViewManager<VolumeView> {
 
     view.setProgress((int)(volume*view.getMax()));
     view.invalidate();
+    view.setTag("volumeView"); //that label is for LayoutController.getTagsForScrollableViews impl
   }
 }


### PR DESCRIPTION
There is some kind of problem when layout view of our player contained within RecyclerView, ui scrollable elements like a progress bar, volume are not getting scroll events. That changes targets to resolve that. PR introduce 2 new methods in LayoutController interface:

setRootRecyclerView - the user should call it if there is RecyclerView used as a root container for the layout of OoyalaPlayer. Currently, it is implemented only for OoyalaSkinLayoutController in SkinSDK.

getTagsForScrollableViews - must be implemented if there is need such support. This method should return an array of string tags for views within OoyalaPlayer layout view which pretends to be scrollable. Currently it is implemented only for OoyalaSkinLayoutController in SkinSDK ("seekBar", "volumeView" returning).