### PR TITLE
[PLAYER-5423] setFullScreen method is made as a public to implement multiple players in a scrolling view

### DIFF
--- a/sdk/android/skin/src/main/java/com/ooyala/android/skin/OoyalaSkinLayout.java
+++ b/sdk/android/skin/src/main/java/com/ooyala/android/skin/OoyalaSkinLayout.java
@@ -180,7 +180,7 @@ public class OoyalaSkinLayout extends FrameLayout implements View.OnSystemUiVisi
    * Stretch OoyalaSkinLayout to dimensions of the display window.
    * Handle system UI visibility.
    */
-  void setFullscreen(boolean fullscreen) {
+  public void setFullscreen(boolean fullscreen) {
     // do nothing if window manager isn't set. This is considering an unexpected case, that is
     // why I'm omitting the whole method, since it really depends on windowManager
     if (null == windowManager) {


### PR DESCRIPTION
The root task: https://jira.corp.ooyala.com/browse/PLAYER-5406

In the sample app, multiple players should be embedded and perform the following:

- As the user scrolls, the video autoplays when the player is fully in view.
- Once scrolling continues, that player should be automatically paused.
- Once scrolling reveals another player and scrolling stops, playback should be automatically started.
- If the user pauses the video, the video will be paused.
- Once scrolling reveals the player with the video that was paused by the user, the video won't play automatically.
- The playhead time is saved for each video and each video starts from the time it was paused.
- If the user unmutes any video player, all future videos should start up unmuted.
Embedded container should use most of the screen when viewed vertically, except for a header taking up some space title "Video Feed Sample App". Video embeds are separated by the text of the video title centered inline on the video list.
- _If the user moves the device to view horizontally while a video is being played, it automatically goes full-screen on the video._
- _If the user returns to portrait mode, the video becomes viewed as embedded in video list again._
- _If a video is not playing while viewed horizontally, then the list is expanded to full width._

To meet _Italic_ ACs I made setFullScreen as a public.
