### PR TITLE
[PLAYER-5504] Refactor `lib` modules code style and fix tests

### DIFF
--- a/sdk/react/.eslintrc
+++ b/sdk/react/.eslintrc
@@ -20,6 +20,7 @@
         "code": 120
       }
     ],
+    "no-console": "error",
     "react/jsx-filename-extension": [
       1,
       {

--- a/sdk/react/.eslintrc
+++ b/sdk/react/.eslintrc
@@ -17,7 +17,8 @@
     "max-len": [
       "error",
       {
-        "code": 120
+        "code": 120,
+        "ignoreTemplateLiterals": true
       }
     ],
     "no-console": "error",

--- a/sdk/react/src/BridgeListener.js
+++ b/sdk/react/src/BridgeListener.js
@@ -2,7 +2,7 @@
 import { Platform } from 'react-native';
 
 import { CONTENT_TYPES, OVERLAY_TYPES, SCREEN_TYPES } from './constants';
-import Log from './lib/log';
+import * as Log from './lib/log';
 import { parseInputArray as parseMarkersInputArray } from './lib/markers';
 
 /**

--- a/sdk/react/src/Core.js
+++ b/sdk/react/src/Core.js
@@ -1,7 +1,7 @@
 import {
   AUTOHIDE_DELAY, BUTTON_NAMES, MAX_DATE_VALUE, OVERLAY_TYPES,
 } from './constants';
-import Log from './lib/log';
+import * as Log from './lib/log';
 import BridgeListener from './BridgeListener';
 import ViewsRenderer from './ViewsRenderer';
 

--- a/sdk/react/src/ViewsRenderer.js
+++ b/sdk/react/src/ViewsRenderer.js
@@ -4,7 +4,7 @@ import { NativeModules, Platform } from 'react-native';
 import {
   BUTTON_NAMES, DESIRED_STATES, OVERLAY_TYPES, SCREEN_TYPES, UI_SIZES,
 } from './constants';
-import Log from './lib/log';
+import * as Log from './lib/log';
 import * as Utils from './lib/utils';
 
 import AdPlaybackScreen from './views/AdPlaybackScreen';

--- a/sdk/react/src/lib/__fixtures__/localizableData.json
+++ b/sdk/react/src/lib/__fixtures__/localizableData.json
@@ -1,0 +1,27 @@
+{
+  "defaultLanguage": "en",
+  "en": {
+    "Learn More": "Learn More",
+    "CLOSED CAPTION PREVIEW": "CLOSED CAPTION PREVIEW",
+    "Sample Text": "Sample Text",
+    "Ad": "Ad",
+    "Skip Ad": "Skip Ad",
+    "LIVE": "LIVE",
+    "GO LIVE": "GO LIVE",
+    "CC Options": "CC Options",
+    "On": "On",
+    "Off": "Off"
+  },
+  "es": {
+    "Learn More": "Más información",
+    "CLOSED CAPTION PREVIEW": "VISTA PRELIMINAR DE SUBTÍTULOS",
+    "Sample Text": "Texto de muestra",
+    "Ad": "Anuncio",
+    "Skip Ad": "Omitir anuncio",
+    "LIVE": "EN VIVO",
+    "GO LIVE": "TRANSMITIR EN VIVO",
+    "CC Options": "Opciones de subtitulado",
+    "On": "Sí",
+    "Off": "No"
+  }
+}

--- a/sdk/react/src/lib/accessibility.js
+++ b/sdk/react/src/lib/accessibility.js
@@ -1,3 +1,5 @@
+// @flow
+
 import {
   ACCESSIBILITY_ANNOUNCERS,
   ACCESSIBILITY_COMMON,
@@ -6,41 +8,45 @@ import {
   VIEW_ACCESSIBILITY_NAMES,
 } from '../constants';
 
-export default class Accessibility {
-  static createAccessibilityLabelForCell(cellType, param) {
-    switch (cellType) {
-      case CELL_TYPES.MULTI_AUDIO:
-        return `${param} ${VIEW_ACCESSIBILITY_NAMES.MULTI_AUDIO_CELL}`;
-      case CELL_TYPES.SUBTITLES:
-        return `${param} ${VIEW_ACCESSIBILITY_NAMES.CC_CELL}`;
-      case CELL_TYPES.PLAYBACK_SPEED_RATE:
-        return `${param} ${VIEW_ACCESSIBILITY_NAMES.PLAYBACK_SPEED_CELL}`;
-      default:
-        return '';
-    }
-  }
+export const createAccessibilityLabelForCell = (cellType, param) => {
+  switch (cellType) {
+    case CELL_TYPES.MULTI_AUDIO:
+      return `${param} ${VIEW_ACCESSIBILITY_NAMES.MULTI_AUDIO_CELL}`;
 
-  static createAccessibilityLabelForSelectedObject(selectedObject) {
-    return `${ACCESSIBILITY_COMMON.SELECTED} ${selectedObject}`;
-  }
+    case CELL_TYPES.SUBTITLES:
+      return `${param} ${VIEW_ACCESSIBILITY_NAMES.CC_CELL}`;
 
-  static createAccessibilityAnnouncers(announcerType, param) {
-    switch (announcerType) {
-      case ANNOUNCER_TYPES.MOVING:
-        return `${ACCESSIBILITY_ANNOUNCERS.PROGRESS_BAR_MOVING + param} %`;
-      case ANNOUNCER_TYPES.MOVED:
-        return `${ACCESSIBILITY_ANNOUNCERS.PROGRESS_BAR_MOVED + param} %`;
-      default:
-        return '';
-    }
-  }
+    case CELL_TYPES.PLAYBACK_SPEED_RATE:
+      return `${param} ${VIEW_ACCESSIBILITY_NAMES.PLAYBACK_SPEED_CELL}`;
 
-  static createAccessibilityForForwardButton(isForward, param, timeUnit) {
-    const baseLabel = isForward ? VIEW_ACCESSIBILITY_NAMES.FORWARD_BUTTON : VIEW_ACCESSIBILITY_NAMES.BACKWARD_BUTTON;
-    return `${baseLabel} ${param} ${timeUnit}`;
+    default:
+      return '';
   }
+};
 
-  static createAccessibilityForPlayPauseButton(buttonName) {
-    return `${buttonName} ${VIEW_ACCESSIBILITY_NAMES.PLAY_PAUSE_BUTTON} ${buttonName}`;
+export const createAccessibilityLabelForSelectedObject = selectedObject => (
+  `${ACCESSIBILITY_COMMON.SELECTED} ${selectedObject}`
+);
+
+export const createAccessibilityAnnouncers = (announcerType, param) => {
+  switch (announcerType) {
+    case ANNOUNCER_TYPES.MOVING:
+      return `${ACCESSIBILITY_ANNOUNCERS.PROGRESS_BAR_MOVING + param} %`;
+
+    case ANNOUNCER_TYPES.MOVED:
+      return `${ACCESSIBILITY_ANNOUNCERS.PROGRESS_BAR_MOVED + param} %`;
+
+    default:
+      return '';
   }
-}
+};
+
+export const createAccessibilityForForwardButton = (isForward, param, timeUnit) => {
+  const baseLabel = isForward ? VIEW_ACCESSIBILITY_NAMES.FORWARD_BUTTON : VIEW_ACCESSIBILITY_NAMES.BACKWARD_BUTTON;
+
+  return `${baseLabel} ${param} ${timeUnit}`;
+};
+
+export const createAccessibilityForPlayPauseButton = buttonName => (
+  `${buttonName} ${VIEW_ACCESSIBILITY_NAMES.PLAY_PAUSE_BUTTON} ${buttonName}`
+);

--- a/sdk/react/src/lib/collapser.test.js
+++ b/sdk/react/src/lib/collapser.test.js
@@ -51,7 +51,7 @@ const data = {
   },
 };
 
-describe('collapser', () => {
+describe('collapse', () => {
   it('TestOverflow_overflowMoreOptionsDoesntCount', () => {
     const oi = [data.B5_Collapsing1, data.B7_MoreOptions100];
     const results = collapse(100, oi);

--- a/sdk/react/src/lib/collapser.test.js
+++ b/sdk/react/src/lib/collapser.test.js
@@ -1,252 +1,239 @@
-jest.dontMock('./collapser.js');
+// @flow
 
-describe('Collapsing Bar Utils', () => {
-  let CollapsingBarUtils;
+import { collapse } from './collapser';
 
-  // _F means 'fixed' or 'featured' (old terminology): not collapsible.
-  // _C means 'collapsible' (which can be overflow or just disappear).
-  const data = {
-    B1_Fixed100: {
-      name: 'b1',
-      location: 'controlBar',
-      whenDoesNotFit: 'keep',
-      minWidth: 100,
-    },
-    B2_Fixed1: {
-      name: 'b2',
-      location: 'controlBar',
-      whenDoesNotFit: 'keep',
-      minWidth: 1,
-    },
-    B3_Fixed1: {
-      name: 'b3',
-      location: 'controlBar',
-      whenDoesNotFit: 'keep',
-      minWidth: 1,
-    },
-    B4_Collapsing100: {
-      name: 'b4',
-      location: 'controlBar',
-      whenDoesNotFit: 'moveToMoreOptions',
-      minWidth: 100,
-    },
-    B5_Collapsing1: {
-      name: 'b5',
-      location: 'controlBar',
-      whenDoesNotFit: 'moveToMoreOptions',
-      minWidth: 1,
-    },
-    B6_Collapsing1: {
-      name: 'b6',
-      location: 'controlBar',
-      whenDoesNotFit: 'moveToMoreOptions',
-      minWidth: 1,
-    },
-    B7_MoreOptions100: {
-      name: 'b7',
-      location: 'moreOptions',
-      minWidth: 100,
-    },
-    B8_None100: {
-      name: 'b7',
-      location: '',
-      minWidth: 100,
-    },
-  };
+const data = {
+  B1_Fixed100: {
+    name: 'b1',
+    location: 'controlBar',
+    whenDoesNotFit: 'keep',
+    minWidth: 100,
+  },
+  B2_Fixed1: {
+    name: 'b2',
+    location: 'controlBar',
+    whenDoesNotFit: 'keep',
+    minWidth: 1,
+  },
+  B3_Fixed1: {
+    name: 'b3',
+    location: 'controlBar',
+    whenDoesNotFit: 'keep',
+    minWidth: 1,
+  },
+  B4_Collapsing100: {
+    name: 'b4',
+    location: 'controlBar',
+    whenDoesNotFit: 'moveToMoreOptions',
+    minWidth: 100,
+  },
+  B5_Collapsing1: {
+    name: 'b5',
+    location: 'controlBar',
+    whenDoesNotFit: 'moveToMoreOptions',
+    minWidth: 1,
+  },
+  B6_Collapsing1: {
+    name: 'b6',
+    location: 'controlBar',
+    whenDoesNotFit: 'moveToMoreOptions',
+    minWidth: 1,
+  },
+  B7_MoreOptions100: {
+    name: 'b7',
+    location: 'moreOptions',
+    minWidth: 100,
+  },
+  B8_None100: {
+    name: 'b7',
+    location: '',
+    minWidth: 100,
+  },
+};
 
-  beforeEach(() => {
-    CollapsingBarUtils = require('./collapser.js');
-  });
-
+describe('collapser', () => {
   it('TestOverflow_overflowMoreOptionsDoesntCount', () => {
     const oi = [data.B5_Collapsing1, data.B7_MoreOptions100];
-    const results = CollapsingBarUtils.collapse(100, oi);
-    expect(results.overflow.length)
-      .toBe(1);
-    expect(results.overflow[0])
-      .toBe(data.B7_MoreOptions100);
+    const results = collapse(100, oi);
+
+    expect(results.overflow.length).toBe(1);
+    expect(results.overflow[0]).toBe(data.B7_MoreOptions100);
   });
 
   it('TestOverflow_overflowMoreOptionsFits', () => {
     const oi = [data.B7_MoreOptions100];
-    const results = CollapsingBarUtils.collapse(100, oi);
-    expect(results.overflow.toString())
-      .toBe(oi.toString());
+    const results = collapse(100, oi);
+
+    expect(results.overflow.toString()).toBe(oi.toString());
   });
 
   it('TestOverflow_overflowMoreOptionsDoesNotFit', () => {
     const oi = [data.B7_MoreOptions100];
-    const results = CollapsingBarUtils.collapse(1, oi);
-    expect(results.overflow.toString())
-      .toBe(oi.toString());
+    const results = collapse(1, oi);
+
+    expect(results.overflow.toString()).toBe(oi.toString());
   });
 
   it('TestOverflow_overflowAppearanceNoneFits', () => {
     const oi = [data.B8_None100];
-    const results = CollapsingBarUtils.collapse(100, oi);
-    expect(results.overflow.length)
-      .toBe(0);
+    const results = collapse(100, oi);
+
+    expect(results.overflow.length).toBe(0);
   });
 
   it('TestOverflow_overflowAppearanceNoneDoesNotFit', () => {
     const oi = [data.B8_None100];
-    const results = CollapsingBarUtils.collapse(1, oi);
-    expect(results.overflow.length)
-      .toBe(0);
+    const results = collapse(1, oi);
+
+    expect(results.overflow.length).toBe(0);
   });
 
   it('TestOverflow_overflowAliasOnlyOnce', () => {
     const oi = [data.B5_Collapsing1, data.B6_Collapsing1, data.B5_Collapsing1];
-    const results = CollapsingBarUtils.collapse(2, oi);
-    expect(results.overflow.length)
-      .toBe(1);
-    expect(results.overflow[0])
-      .toBe(data.B5_Collapsing1);
+    const results = collapse(2, oi);
+
+    expect(results.overflow.length).toBe(1);
+    expect(results.overflow[0]).toBe(data.B5_Collapsing1);
   });
 
   it('TestOverflow_overflowFixedMixed', () => {
     const oi = [data.B1_Fixed100, data.B5_Collapsing1];
-    const results = CollapsingBarUtils.collapse(1, oi);
-    expect(results.overflow.length)
-      .toBe(1);
-    expect(results.overflow[0])
-      .toBe(data.B5_Collapsing1);
+    const results = collapse(1, oi);
+
+    expect(results.overflow.length).toBe(1);
+    expect(results.overflow[0]).toBe(data.B5_Collapsing1);
   });
 
   it('TestOverflow_overflowFixedSingle', () => {
     const oi = [data.B1_Fixed100];
-    const results = CollapsingBarUtils.collapse(1, oi);
-    expect(results.overflow.length)
-      .toBe(0);
+    const results = collapse(1, oi);
+
+    expect(results.overflow.length).toBe(0);
   });
 
   it('TestFit_fixedPreferred', () => {
     const oi = [data.B2_Fixed1, data.B5_Collapsing1, data.B3_Fixed1];
-    const results = CollapsingBarUtils.collapse(2, oi);
-    expect(results.fit.length)
-      .toBe(2);
-    expect(results.fit.indexOf(data.B5_Collapsing1))
-      .toBe(-1);
+    const results = collapse(2, oi);
+
+    expect(results.fit.length).toBe(2);
+    expect(results.fit.indexOf(data.B5_Collapsing1)).toBe(-1);
   });
 
   it('TestFit_merging', () => {
     const oi = [data.B2_Fixed1, data.B5_Collapsing1, data.B3_Fixed1];
-    const results = CollapsingBarUtils.collapse(100, oi);
-    expect(results.fit.length)
-      .toBe(3);
-    expect(results.fit.toString())
-      .toBe(oi.toString());
+    const results = collapse(100, oi);
+
+    expect(results.fit.length).toBe(3);
+    expect(results.fit.toString()).toBe(oi.toString());
   });
 
   it('TestFit_revKeepFixed', () => {
-    const results = CollapsingBarUtils.collapse(100, [data.B4_Collapsing100, data.B1_Fixed100]);
-    expect(results.fit.length)
-      .toBe(1);
-    expect(results.fit[0])
-      .toBe(data.B1_Fixed100);
+    const results = collapse(100, [data.B4_Collapsing100, data.B1_Fixed100]);
+
+    expect(results.fit.length).toBe(1);
+    expect(results.fit[0]).toBe(data.B1_Fixed100);
   });
 
   it('TestFit_keepFixed', () => {
-    const results = CollapsingBarUtils.collapse(100, [data.B1_Fixed100, data.B4_Collapsing100]);
-    expect(results.fit.length)
-      .toBe(1);
-    expect(results.fit[0])
-      .toBe(data.B1_Fixed100);
+    const results = collapse(100, [data.B1_Fixed100, data.B4_Collapsing100]);
+
+    expect(results.fit.length).toBe(1);
+    expect(results.fit[0]).toBe(data.B1_Fixed100);
   });
 
   it('TestFit_revOneCollapsableFits', () => {
-    const results = CollapsingBarUtils.collapse(100, [data.B5_Collapsing1, data.B4_Collapsing100]);
-    expect(results.fit.length)
-      .toBe(1);
-    expect(results.fit[0])
-      .toBe(data.B5_Collapsing1);
+    const results = collapse(100, [data.B5_Collapsing1, data.B4_Collapsing100]);
+
+    expect(results.fit.length).toBe(1);
+    expect(results.fit[0]).toBe(data.B5_Collapsing1);
   });
 
   it('TestFit_oneCollapsableFits', () => {
-    const results = CollapsingBarUtils.collapse(100, [data.B4_Collapsing100, data.B5_Collapsing1]);
-    expect(results.fit.length)
-      .toBe(1);
-    expect(results.fit[0])
-      .toBe(data.B4_Collapsing100);
+    const results = collapse(100, [data.B4_Collapsing100, data.B5_Collapsing1]);
+
+    expect(results.fit.length).toBe(1);
+    expect(results.fit[0]).toBe(data.B4_Collapsing100);
   });
 
   it('TestFit_collapsableFits', () => {
-    const results = CollapsingBarUtils.collapse(100, [data.B4_Collapsing100]);
-    expect(results.fit.length)
-      .toBe(1);
-    expect(results.fit[0])
-      .toBe(data.B4_Collapsing100);
+    const results = collapse(100, [data.B4_Collapsing100]);
+
+    expect(results.fit.length).toBe(1);
+    expect(results.fit[0]).toBe(data.B4_Collapsing100);
   });
 
   it('TestFit_allFixedFit', () => {
-    const results = CollapsingBarUtils.collapse(100, [data.B2_Fixed1, data.B3_Fixed1]);
-    expect(results.fit.length)
-      .toBe(2);
-    expect(results.fit[0])
-      .toBe(data.B2_Fixed1);
-    expect(results.fit[1])
-      .toBe(data.B3_Fixed1);
+    const results = collapse(100, [data.B2_Fixed1, data.B3_Fixed1]);
+
+    expect(results.fit.length).toBe(2);
+    expect(results.fit[0]).toBe(data.B2_Fixed1);
+    expect(results.fit[1]).toBe(data.B3_Fixed1);
   });
 
   it('TestFit_revOneFixedFits_twoFixed', () => {
     const oi = [data.B2_Fixed1, data.B1_Fixed100];
-    const results = CollapsingBarUtils.collapse(100, oi);
-    expect(results.fit.length)
-      .toBe(2);
-    expect(results.fit.toString())
-      .toBe(oi.toString());
+    const results = collapse(100, oi);
+
+    expect(results.fit.length).toBe(2);
+    expect(results.fit.toString()).toBe(oi.toString());
   });
 
   it('TestFit_oneFixedFits_twoFixed', () => {
     const oi = [data.B1_Fixed100, data.B2_Fixed1];
-    const results = CollapsingBarUtils.collapse(100, oi);
-    expect(results.fit.length)
-      .toBe(2);
-    expect(results.fit.toString())
-      .toBe(oi.toString());
+    const results = collapse(100, oi);
+
+    expect(results.fit.length).toBe(2);
+    expect(results.fit.toString()).toBe(oi.toString());
   });
 
   it('TestFit_keepItemMeetingSpec', () => {
-    const results = CollapsingBarUtils.collapse(100, [data.B2_Fixed1]);
-    expect(results.fit.length)
-      .toBe(1);
+    const results = collapse(100, [data.B2_Fixed1]);
+
+    expect(results.fit.length).toBe(1);
   });
 
   it('TestFit_discardInvalidItem_overflow', () => {
-    const results = CollapsingBarUtils.collapse(100, [{
-      name: 'b1',
-      appearance: 'controlBar',
-    }]);
-    expect(results.overflow.length)
-      .toBe(0);
-  });
-
-  it('TestFit_discardInvalidItem_fit', () => {
-    const results = CollapsingBarUtils.collapse(100, [{
-      name: 'b1',
-      appearance: 'controlBar',
-    }]);
-    expect(results.fit.length)
-      .toBe(0);
-  });
-
-  it('TestFit_discardInvalidItemsInZeroSpace', () => {
-    const results = CollapsingBarUtils.collapse(0, [data.B2_Fixed1,
+    const results = collapse(100, [
       {
         name: 'b1',
         appearance: 'controlBar',
-      }]);
-    expect(results.fit.length)
-      .toBe(1);
+      },
+    ]);
+
+    expect(results.overflow.length).toBe(0);
+  });
+
+  it('TestFit_discardInvalidItem_fit', () => {
+    const results = collapse(100, [
+      {
+        name: 'b1',
+        appearance: 'controlBar',
+      },
+    ]);
+
+    expect(results.fit.length).toBe(0);
+  });
+
+  it('TestFit_discardInvalidItemsInZeroSpace', () => {
+    const results = collapse(0, [
+      data.B2_Fixed1,
+      {
+        name: 'b1',
+        appearance: 'controlBar',
+      },
+    ]);
+
+    expect(results.fit.length).toBe(1);
   });
 
   it('TestFit_constiousEdgeCasesDoNotExplode', () => {
     const sizes = [undefined, null, -1, 0, -4096, 4096];
     const items = [undefined, null, [], ['foo']];
-    for (let si = 0; si < sizes.length; ++si) {
-      for (let ii = 0; ii < items.length; ++ii) {
-        // not saying it returns anything sane, just doesn't die.
-        CollapsingBarUtils.collapse(sizes[si], items[ii]);
+
+    for (let si = 0; si < sizes.length; si += 1) {
+      for (let ii = 0; ii < items.length; ii += 1) {
+        // Not saying it returns anything sane, just doesn't die.
+        collapse(sizes[si], items[ii]);
       }
     }
   });

--- a/sdk/react/src/lib/log.js
+++ b/sdk/react/src/lib/log.js
@@ -1,66 +1,83 @@
+// @flow
+
 import { LOG_LEVEL } from '../constants';
 
-let level = LOG_LEVEL.INFO;
+let globalLevel = LOG_LEVEL.INFO;
 
 export default class Log {
-  static setLogLevel(l) {
-    switch (l) {
+  /* eslint-disable no-console */
+
+  static setLogLevel(level) {
+    switch (level) {
       case LOG_LEVEL.VERBOSE:
       case LOG_LEVEL.INFO:
       case LOG_LEVEL.WARN:
       case LOG_LEVEL.ERROR:
       case LOG_LEVEL.NONE:
-        level = l;
+        globalLevel = level;
         break;
+
       default:
-        console.error(`Invalid Warning Level: ${l}`);
+        console.error(`Invalid Warning Level: ${level}`);
         break;
     }
   }
 
   static warn(msg) {
-    if (level >= LOG_LEVEL.WARN) {
+    if (globalLevel >= LOG_LEVEL.WARN) {
       console.warn(msg);
+
       return true;
     }
+
     return false;
   }
 
   static info(msg) {
-    if (level >= LOG_LEVEL.INFO) {
+    if (globalLevel >= LOG_LEVEL.INFO) {
       console.info(msg);
+
       return true;
     }
+
     return false;
   }
 
   static error(msg) {
-    if (level >= LOG_LEVEL.ERROR) {
+    if (globalLevel >= LOG_LEVEL.ERROR) {
       console.error(msg);
+
       return true;
     }
+
     return false;
   }
 
   static log(msg) {
-    if (level >= LOG_LEVEL.INFO) {
+    if (globalLevel >= LOG_LEVEL.INFO) {
       console.log(msg);
+
       return true;
     }
+
     return false;
   }
 
   static verbose(msg) {
-    if (level >= LOG_LEVEL.VERBOSE) {
+    if (globalLevel >= LOG_LEVEL.VERBOSE) {
       console.log(msg);
+
       return true;
     }
+
     return false;
   }
 
   static assertTrue(condition, msg) {
     if (condition) {
-      error('ASSERT FAILED: ', msg);
+      this.error('ASSERT FAILED: ', msg);
     }
   }
+
+  /* eslint-enable no-console */
 }

--- a/sdk/react/src/lib/log.js
+++ b/sdk/react/src/lib/log.js
@@ -1,83 +1,78 @@
 // @flow
+/* eslint-disable no-console */
 
 import { LOG_LEVEL } from '../constants';
 
 let globalLevel = LOG_LEVEL.INFO;
 
-export default class Log {
-  /* eslint-disable no-console */
+export const setLogLevel = (level) => {
+  switch (level) {
+    case LOG_LEVEL.VERBOSE:
+    case LOG_LEVEL.INFO:
+    case LOG_LEVEL.WARN:
+    case LOG_LEVEL.ERROR:
+    case LOG_LEVEL.NONE:
+      globalLevel = level;
+      break;
 
-  static setLogLevel(level) {
-    switch (level) {
-      case LOG_LEVEL.VERBOSE:
-      case LOG_LEVEL.INFO:
-      case LOG_LEVEL.WARN:
-      case LOG_LEVEL.ERROR:
-      case LOG_LEVEL.NONE:
-        globalLevel = level;
-        break;
+    default:
+      console.error(`Invalid Warning Level: ${level}`);
+      break;
+  }
+};
 
-      default:
-        console.error(`Invalid Warning Level: ${level}`);
-        break;
-    }
+export const warn = (msg) => {
+  if (globalLevel >= LOG_LEVEL.WARN) {
+    console.warn(msg);
+
+    return true;
   }
 
-  static warn(msg) {
-    if (globalLevel >= LOG_LEVEL.WARN) {
-      console.warn(msg);
+  return false;
+};
 
-      return true;
-    }
+export const info = (msg) => {
+  if (globalLevel >= LOG_LEVEL.INFO) {
+    console.info(msg);
 
-    return false;
+    return true;
   }
 
-  static info(msg) {
-    if (globalLevel >= LOG_LEVEL.INFO) {
-      console.info(msg);
+  return false;
+};
 
-      return true;
-    }
+export const error = (msg) => {
+  if (globalLevel >= LOG_LEVEL.ERROR) {
+    console.error(msg);
 
-    return false;
+    return true;
   }
 
-  static error(msg) {
-    if (globalLevel >= LOG_LEVEL.ERROR) {
-      console.error(msg);
+  return false;
+};
 
-      return true;
-    }
+export const log = (msg) => {
+  if (globalLevel >= LOG_LEVEL.INFO) {
+    console.log(msg);
 
-    return false;
+    return true;
   }
 
-  static log(msg) {
-    if (globalLevel >= LOG_LEVEL.INFO) {
-      console.log(msg);
+  return false;
+};
 
-      return true;
-    }
+export const verbose = (msg) => {
+  if (globalLevel >= LOG_LEVEL.VERBOSE) {
+    console.log(msg);
 
-    return false;
+    return true;
   }
 
-  static verbose(msg) {
-    if (globalLevel >= LOG_LEVEL.VERBOSE) {
-      console.log(msg);
+  return false;
+};
 
-      return true;
-    }
-
-    return false;
+export const assertTrue = (condition, msg) => {
+  if (condition) {
+    this.error('ASSERT FAILED: ', msg);
   }
-
-  static assertTrue(condition, msg) {
-    if (condition) {
-      this.error('ASSERT FAILED: ', msg);
-    }
-  }
-
-  /* eslint-enable no-console */
-}
+};

--- a/sdk/react/src/lib/log.test.js
+++ b/sdk/react/src/lib/log.test.js
@@ -1,70 +1,44 @@
-jest.dontMock('../log.js');
+// @flow
 
-describe('Log Tests', function () {
+import { LOG_LEVEL } from '../constants';
+import Log from './log';
 
-  let Log;
-
-  import {
-    LOG_LEVEL,
-  } from '../constants';
-
-  beforeEach(function () {
-    Log = require('./log.js');
+describe('Log', () => {
+  it('logs everything except verbose by default', () => {
+    expect(Log.verbose('test')).toBe(false);
+    expect(Log.log('test')).toBe(true);
+    expect(Log.info('test')).toBe(true);
+    expect(Log.warn('test')).toBe(true);
+    expect(Log.error('test')).toBe(true);
   });
 
-  it('Default Log is everything but verbose', function () {
-    expect(Log.verbose('hello log'))
-      .toBe(false);
-    expect(Log.log('hello log'))
-      .toBe(true);
-    expect(Log.info('hello log'))
-      .toBe(true);
-    expect(Log.warn('hello log'))
-      .toBe(true);
-    expect(Log.error('hello log'))
-      .toBe(true);
-  });
-
-  it('VERBOSE Log is everything but verbose', function () {
+  it('logs everything when VERBOSE level set', () => {
     Log.setLogLevel(LOG_LEVEL.VERBOSE);
-    expect(Log.verbose('hello log'))
-      .toBe(true);
-    expect(Log.log('hello log'))
-      .toBe(true);
-    expect(Log.info('hello log'))
-      .toBe(true);
-    expect(Log.warn('hello log'))
-      .toBe(true);
-    expect(Log.error('hello log'))
-      .toBe(true);
+
+    expect(Log.verbose('test')).toBe(true);
+    expect(Log.log('test')).toBe(true);
+    expect(Log.info('test')).toBe(true);
+    expect(Log.warn('test')).toBe(true);
+    expect(Log.error('test')).toBe(true);
   });
 
-  it('ERROR Log is everything but verbose', function () {
+  it('logs only errors when ERROR level set', () => {
     Log.setLogLevel(LOG_LEVEL.ERROR);
-    expect(Log.verbose('hello log'))
-      .toBe(false);
-    expect(Log.log('hello log'))
-      .toBe(false);
-    expect(Log.info('hello log'))
-      .toBe(false);
-    expect(Log.warn('hello log'))
-      .toBe(false);
-    expect(Log.error('hello log'))
-      .toBe(true);
+
+    expect(Log.verbose('test')).toBe(false);
+    expect(Log.log('test')).toBe(false);
+    expect(Log.info('test')).toBe(false);
+    expect(Log.warn('test')).toBe(false);
+    expect(Log.error('test')).toBe(true);
   });
 
-  it('NONE Log is everything but verbose', function () {
+  it('logs nothing when NONE level set', () => {
     Log.setLogLevel(LOG_LEVEL.NONE);
-    expect(Log.verbose('hello log'))
-      .toBe(false);
-    expect(Log.log('hello log'))
-      .toBe(false);
-    expect(Log.info('hello log'))
-      .toBe(false);
-    expect(Log.warn('hello log'))
-      .toBe(false);
-    expect(Log.error('hello log'))
-      .toBe(false);
-  });
 
+    expect(Log.verbose('test')).toBe(false);
+    expect(Log.log('test')).toBe(false);
+    expect(Log.info('test')).toBe(false);
+    expect(Log.warn('test')).toBe(false);
+    expect(Log.error('test')).toBe(false);
+  });
 });

--- a/sdk/react/src/lib/log.test.js
+++ b/sdk/react/src/lib/log.test.js
@@ -1,7 +1,7 @@
 // @flow
 
 import { LOG_LEVEL } from '../constants';
-import Log from './log';
+import * as Log from './log';
 
 describe('Log', () => {
   it('logs everything except verbose by default', () => {

--- a/sdk/react/src/lib/markers.js
+++ b/sdk/react/src/lib/markers.js
@@ -1,6 +1,6 @@
 // @flow
 
-import Log from './log';
+import * as Log from './log';
 import type { Marker } from '../types/Markers';
 
 // eslint-disable-next-line import/prefer-default-export

--- a/sdk/react/src/lib/markers.test.js
+++ b/sdk/react/src/lib/markers.test.js
@@ -9,22 +9,19 @@ describe('parseInputArray', () => {
       '{"start": "start", "type": "icon", "iconUrl": "http://example.com/icon.png"}',
     ]);
 
-    expect(parsed)
-      .toHaveLength(2);
+    expect(parsed).toHaveLength(2);
 
-    expect(parsed[0])
-      .toEqual({
-        start: 'start',
-        type: 'text',
-        text: 'Hello, world!',
-      });
+    expect(parsed[0]).toEqual({
+      start: 'start',
+      type: 'text',
+      text: 'Hello, world!',
+    });
 
-    expect(parsed[1])
-      .toEqual({
-        start: 'start',
-        type: 'icon',
-        iconUrl: 'http://example.com/icon.png',
-      });
+    expect(parsed[1]).toEqual({
+      start: 'start',
+      type: 'icon',
+      iconUrl: 'http://example.com/icon.png',
+    });
   });
 
   it('skips wrong strings', () => {
@@ -33,23 +30,19 @@ describe('parseInputArray', () => {
       'ERROR{"start": "start", "type": "icon", "iconUrl": "http://example.com/icon.png"}',
     ]);
 
-    expect(parsed)
-      .toHaveLength(1);
+    expect(parsed).toHaveLength(1);
 
-    expect(parsed[0])
-      .toEqual({
-        start: 'start',
-        type: 'text',
-        text: 'Hello, world!',
-      });
+    expect(parsed[0]).toEqual({
+      start: 'start',
+      type: 'text',
+      text: 'Hello, world!',
+    });
   });
 
   it('returns empty array if the parameter is falsy', () => {
     const parsed = parseInputArray();
 
-    expect(Array.isArray(parsed))
-      .toBe(true);
-    expect(parsed)
-      .toHaveLength(0);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed).toHaveLength(0);
   });
 });

--- a/sdk/react/src/lib/responsiveMultiplier.js
+++ b/sdk/react/src/lib/responsiveMultiplier.js
@@ -1,6 +1,6 @@
 // @flow
 
-import Log from './log';
+import * as Log from './log';
 
 const defaultMultipliers = [0.7, 1, 1.2];
 const defaultThresholds = [320, 860];

--- a/sdk/react/src/lib/responsiveMultiplier.js
+++ b/sdk/react/src/lib/responsiveMultiplier.js
@@ -1,170 +1,63 @@
+// @flow
+
 import Log from './log';
 
-export default {
+const defaultMultipliers = [0.7, 1, 1.2];
+const defaultThresholds = [320, 860];
 
-  // Default threshold and multiplier
-  default_threshold: [320, 860],
-  default_multiplier: [0.7, 1, 1.2],
+/**
+ * Takes the width and the threshold and returns an integer that represents which threshold the player width currently
+ * lies in.
+ *
+ * @param width
+ * @param thresholds
+ * @returns {number}
+ */
+const getSize = (width, thresholds) => {
+  const usedThresholds = thresholds || defaultThresholds;
 
-  /**
-   * getSize takes the width and the threshold and returns an integer
-   * that represents which threshold the player width currently lies in.
-   *
-   * @param width
-   * @param threshold
-   * @returns {number}
-   */
-  getSize(width, threshold) {
-    const used_threshold = threshold || this.default_threshold;
-    for (let i = 0; i < used_threshold.length; i++) {
-      if (width <= used_threshold[i]) {
-        return parseInt(i);
-      }
+  for (let i = 0; i < usedThresholds.length; i += 1) {
+    if (width <= usedThresholds[i]) {
+      return parseInt(i, 10);
     }
-    return used_threshold.length;
-  },
+  }
 
-  /**
-   * makeResponsiveMultiplier calculates the responsive value by multiplying a
-   * constant to the current size of an element based on how big the screen is.
-   *
-   * @param width
-   * @param threshold
-   * @param multiplier
-   * @param baseSize
-   * @returns {number}
-   */
-  makeResponsiveMultiplier(width, baseSize, multiplier, threshold) {
-    const size = this.getSize(width, threshold);
-    const multipliers = multiplier || this.default_multiplier;
+  return usedThresholds.length;
+};
 
-    if (typeof baseSize === 'number'
-      && typeof multipliers === 'object'
-      && multipliers.length > 0) {
-      if (size >= multipliers.length) {
-        Log.warn(`Warning: No multiplier value available for size ${size} in multiplier array [${multipliers}], falling back to the largest multiplier value available. Length of multiplier array should be one more than the length of the threshold array.`);
-        return baseSize * multipliers[multipliers.length - 1];
-      }
-      return baseSize * multipliers[size];
+/**
+ * Calculates the responsive value by multiplying a constant to the current size of an element based on how big the
+ * screen is.
+ *
+ * @param width
+ * @param thresholds
+ * @param multipliers
+ * @param baseSize
+ * @returns {number}
+ */
+export default (width, baseSize, multipliers, thresholds) => {
+  const size = getSize(width, thresholds);
+  const usedMultipliers = multipliers || defaultMultipliers;
+
+  if (typeof baseSize === 'number' && typeof usedMultipliers === 'object' && usedMultipliers.length > 0) {
+    if (size >= usedMultipliers.length) {
+      Log.warn(
+        `Warning: No multiplier value available for size ${size} in multiplier array [${usedMultipliers}], falling back to the largest multiplier value available. Length of multiplier array should be one more than the length of the threshold array.`,
+      );
+
+      return baseSize * usedMultipliers[usedMultipliers.length - 1];
     }
-    if (typeof baseSize !== 'number') {
-      Log.warn('Warning: baseSize must be a number.');
-    }
-    if (typeof multipliers !== 'object' || multipliers.length <= 0) {
-      Log.warn('Warning: multiplier must be a non empty array.');
-    }
-    return 0;
-  },
 
-  /**
-   * makeResponsiveValues calculates the responsive value by taking the value from
-   * an array that specifies specific values at each threshold.
-   *
-   * @param width
-   * @param threshold
-   * @param values
-   * @returns {number}
-   */
-  makeResponsiveValues(width, values, threshold) {
-    const size = this.getSize(width, threshold);
+    return baseSize * usedMultipliers[size];
+  }
 
-    if (typeof values === 'object' && values.length > 0) {
-      if (size >= values.length) {
-        Log.warn(`Warning: No value available for size ${size} in values array [${values}], falling back to the largest value available. Length of values array should be one more than the length of the threshold array.`);
-        return values[values.length - 1];
-      }
-      return values[size];
-    }
-    Log.warn('Warning: values must be a non empty array.');
-    return 0;
-  },
+  if (typeof baseSize !== 'number') {
+    Log.warn('Warning: baseSize must be a number.');
+  }
 
-  /**
-   * Contains testcases
-   */
-  TestSuite: {
+  if (typeof usedMultipliers !== 'object' || usedMultipliers.length <= 0) {
+    Log.warn('Warning: multiplier must be a non empty array.');
+  }
 
-    Assert() {
-      const b = arguments[0];
-      if (!b) {
-        throw new Error(`ASSERTION FAILED: ${JSON.stringify(arguments)}`);
-      }
-    },
-    AssertStrictEquals() {
-      const o1 = arguments[0];
-      const o2 = arguments[1];
-      if (o1 !== o2) {
-        let errorMessage = `ASSERTION FAILED: ${JSON.stringify(o1)} !== ${JSON.stringify(o2)}`;
-        if (arguments.length > 2) {
-          errorMessage += ` (${JSON.stringify(Array.prototype.slice.call(arguments, 2))})`;
-        }
-        throw new Error(errorMessage);
-      }
-    },
-
-    TestResponsive_multiplier_medium() {
-      const responsive = ResponsiveMultiplier.makeResponsiveMultiplier(500, 100, [1, 2, 3], [200, 800]);
-      this.AssertStrictEquals(responsive, 200, responsive);
-    },
-
-    TestResponsive_multiplier_medium_default() {
-      const responsive = ResponsiveMultiplier.makeResponsiveMultiplier(500, 100);
-      this.AssertStrictEquals(responsive, 100, responsive);
-    },
-
-    TestResponsive_multiplier_small() {
-      const responsive = ResponsiveMultiplier.makeResponsiveMultiplier(100, 100, [1, 2, 3], [200, 800]);
-      this.AssertStrictEquals(responsive, 100, responsive);
-    },
-
-    TestResponsive_multiplier_small_border() {
-      const responsive = ResponsiveMultiplier.makeResponsiveMultiplier(200, 100, [1, 2, 3], [200, 800]);
-      this.AssertStrictEquals(responsive, 100, responsive);
-    },
-
-    TestResponsive_multiplier_large_border() {
-      const responsive = ResponsiveMultiplier.makeResponsiveMultiplier(800, 100, [1, 2, 3], [200, 800]);
-      this.AssertStrictEquals(responsive, 200, responsive);
-    },
-
-    TestResponsive_multiplier_large() {
-      const responsive = ResponsiveMultiplier.makeResponsiveMultiplier(900, 100, [1, 2, 3], [200, 800]);
-      this.AssertStrictEquals(responsive, 300, responsive);
-    },
-
-    TestResponsive_multiplier_overflow() {
-      const responsive = ResponsiveMultiplier.makeResponsiveMultiplier(900, 100, [1], [200, 800]);
-      this.AssertStrictEquals(responsive, 100, responsive);
-    },
-
-    TestResponsive_values_medium() {
-      const responsive = ResponsiveMultiplier.makeResponsiveValues(500, [200, 300, 400], [200, 800]);
-      this.AssertStrictEquals(responsive, 300, responsive);
-    },
-
-    TestResponsive_values_overflow() {
-      const responsive = ResponsiveMultiplier.makeResponsiveValues(500, [200], [200, 800]);
-      this.AssertStrictEquals(responsive, 200, responsive);
-    },
-
-    TestResponsive_values_empty_array() {
-      const responsive = ResponsiveMultiplier.makeResponsiveValues(500, [], [200, 800]);
-      this.AssertStrictEquals(responsive, 0, responsive);
-    },
-
-    Run() {
-      const keys = Object.keys(this)
-        .sort();
-      for (const key of keys) {
-        const isFunction = typeof (this[key]) === 'function';
-        const isTest = key.indexOf('Test') == 0;
-        if (isFunction && isTest) {
-          Log.log('+++', key);
-          this[key]();
-          Log.log('---', key, 'PASS!');
-        }
-      }
-      Log.log('ran', keys.length, 'tests.');
-    },
-  },
+  return 0;
 };

--- a/sdk/react/src/lib/responsiveMultiplier.test.js
+++ b/sdk/react/src/lib/responsiveMultiplier.test.js
@@ -1,40 +1,33 @@
-jest.dontMock('./responsiveMultiplier.js');
+// @flow
 
-describe('Responsive Design Manager', () => {
-  let ResponsiveDesignManager;
+import responsiveMultiplier from './responsiveMultiplier';
 
-  const data = {
-    thresholds: [320, 860],
-  };
-
-  beforeEach(() => {
-    ResponsiveDesignManager = require('./responsiveMultiplier.js');
+describe('responsiveMultiplier', () => {
+  it('small', () => {
+    expect(responsiveMultiplier(100, 100, [1, 2, 3], [200, 800])).toBe(100);
   });
 
-  it('Get Size should return 0  when below lowest threshold ', () => {
-    expect(ResponsiveDesignManager.getSize(0, data.thresholds))
-      .toBe(0);
-    expect(ResponsiveDesignManager.getSize(1, data.thresholds))
-      .toBe(0);
-    expect(ResponsiveDesignManager.getSize(319, data.thresholds))
-      .toBe(0);
-    expect(ResponsiveDesignManager.getSize(320, data.thresholds))
-      .toBe(0);
+  it('small edge case', () => {
+    expect(responsiveMultiplier(200, 100, [1, 2, 3], [200, 800])).toBe(100);
   });
 
-  it('Get Size should return 1  when above lowest threshold ', () => {
-    expect(ResponsiveDesignManager.getSize(321, data.thresholds))
-      .toBe(1);
-    expect(ResponsiveDesignManager.getSize(859, data.thresholds))
-      .toBe(1);
-    expect(ResponsiveDesignManager.getSize(860, data.thresholds))
-      .toBe(1);
+  it('medium', () => {
+    expect(responsiveMultiplier(500, 100, [1, 2, 3], [200, 800])).toBe(200);
   });
 
-  it('Get Size should return 2  when above next threshold ', () => {
-    expect(ResponsiveDesignManager.getSize(861, data.thresholds))
-      .toBe(2);
-    expect(ResponsiveDesignManager.getSize(100000, data.thresholds))
-      .toBe(2);
+  it('medium default', () => {
+    expect(responsiveMultiplier(500, 100)).toBe(100);
+  });
+
+  it('large edge case', () => {
+    expect(responsiveMultiplier(800, 100, [1, 2, 3], [200, 800])).toBe(200);
+  });
+
+  it('large', () => {
+    expect(responsiveMultiplier(900, 100, [1, 2, 3], [200, 800])).toBe(300);
+  });
+
+  it('overflow', () => {
+    expect(responsiveMultiplier(900, 100, [1], [200, 800])).toBe(100);
   });
 });

--- a/sdk/react/src/lib/utils.js
+++ b/sdk/react/src/lib/utils.js
@@ -1,7 +1,7 @@
 // @flow
 
 import { VALUES } from '../constants';
-import Log from './log';
+import * as Log from './log';
 
 export const shouldShowLandscape = (width, height) => {
   if (Number.isNaN(width) || Number.isNaN(height) || width === null || height === null || width < 0 || height < 0) {

--- a/sdk/react/src/lib/utils.js
+++ b/sdk/react/src/lib/utils.js
@@ -1,10 +1,10 @@
+// @flow
+
 import { VALUES } from '../constants';
 import Log from './log';
 
 export const shouldShowLandscape = (width, height) => {
-  if (isNaN(width) || isNaN(height)
-    || width === null || height === null
-    || width < 0 || height < 0) {
+  if (Number.isNaN(width) || Number.isNaN(height) || width === null || height === null || width < 0 || height < 0) {
     return false;
   }
 
@@ -12,8 +12,7 @@ export const shouldShowLandscape = (width, height) => {
 };
 
 export const formattedPlaybackSpeedRate = (selectedPlaybackSpeedRate) => {
-  const selectedPlaybackSpeedRateFloat = parseFloat(parseFloat(String(selectedPlaybackSpeedRate))
-    .toFixed(2));
+  const selectedPlaybackSpeedRateFloat = parseFloat(parseFloat(String(selectedPlaybackSpeedRate)).toFixed(2));
   const selectedPlaybackSpeedRateString = selectedPlaybackSpeedRateFloat.toString();
 
   return selectedPlaybackSpeedRateString.concat('x');
@@ -23,9 +22,9 @@ export const getTimerLabel = (timer) => {
   let timerLabel = '';
 
   if (timer < 10) {
-    timerLabel = `00:0${(timer | 0).toString()}`;
+    timerLabel = `00:0${(timer || '0').toString()}`;
   } else if (timer < 60) {
-    timerLabel = `00:${(timer | 0).toString()}`;
+    timerLabel = `00:${(timer || '0').toString()}`;
   } else if (timer < 600) {
     timerLabel = `0${(timer / 60).toString()}:${(timer % 60).toString()}`;
   } else {
@@ -35,32 +34,36 @@ export const getTimerLabel = (timer) => {
   return timerLabel;
 };
 
-export const isPlaying = rate => rate > 0;
-
-export const isPaused = rate => rate == 0;
-
-export const secondsToString = (seconds) => {
+export const secondsToString = (inputSeconds) => {
   let minus = '';
+  let seconds = inputSeconds;
+
   if (seconds < 0) {
     minus = '-';
     seconds = -seconds;
   }
+
   const date = new Date(seconds * 1000);
   const hh = date.getUTCHours();
   let mm = date.getUTCMinutes();
   let ss = date.getSeconds();
+
   if (ss < 10) {
     ss = `0${ss}`;
   }
-  if (mm == 0) {
+
+  if (mm === 0) {
     mm = '00';
   } else if (mm < 10) {
     mm = `0${mm}`;
   }
+
   let t = `${mm}:${ss}`;
+
   if (hh > 0) {
     t = `${hh}:${t}`;
   }
+
   return minus + t;
 };
 
@@ -68,138 +71,191 @@ export const localizedString = (preferredLocale, stringId, localizableStrings) =
   if (typeof stringId !== 'string') {
     return null;
   }
-  if (typeof preferredLocale !== 'string') {
-    preferredLocale = undefined;
-  }
-  if (typeof localizableStrings !== 'object' || localizableStrings === null) {
-    localizableStrings = {};
-  }
 
-  Log.verbose(`preferredLocale: ${preferredLocale}, stringId: ${stringId}, localizableStrings:`);
-  const defaultLocale = localizableStrings.defaultLanguage || 'en';
+  let locale = preferredLocale;
+  let strings = localizableStrings;
 
-  if (preferredLocale
-    && localizableStrings[preferredLocale]
-    && localizableStrings[preferredLocale][stringId]) {
-    return localizableStrings[preferredLocale][stringId];
+  if (typeof locale !== 'string') {
+    locale = undefined;
   }
 
-  if (localizableStrings[defaultLocale] && localizableStrings[defaultLocale][stringId]) {
-    return localizableStrings[defaultLocale][stringId];
+  if (typeof strings !== 'object' || strings === null) {
+    strings = {};
+  }
+
+  Log.verbose(`preferredLocale: ${locale}, stringId: ${stringId}, localizableStrings:`);
+
+  const defaultLocale = strings.defaultLanguage || 'en';
+
+  if (locale && strings[locale] && strings[locale][stringId]) {
+    return strings[locale][stringId];
+  }
+
+  if (strings[defaultLocale] && strings[defaultLocale][stringId]) {
+    return strings[defaultLocale][stringId];
   }
 
   return stringId;
 };
 
-/**
- * Takes an integer error code andd locale
- * Returns the localized error message
- */
 export const stringForErrorCode = (errorCode) => {
   switch (errorCode) {
-    /* Authorization failed - TODO add to language files */
     case 0:
+      // Authorization failed
+      // TODO: Add to language files.
       return 'Authorization failed';
-    /* Authorization response invalid - TODO add to language files */
+
     case 1:
+      // Authorization response invalid
+      // TODO: Add to language files.
       return 'Invalid Authorization Response';
-    /* Authorization heartbeat failed */
+
     case 2:
+      // Authorization heartbeat failed
       return 'Invalid Heartbeat';
-    /* Content tree response invalid - TODO add to language files */
+
     case 3:
+      // Content tree response invalid
+      // TODO: Add to language files.
       return 'Content Tree Response Invalid';
-    /* Authorization signature invalid - TODO add to language files */
+
     case 4:
+      // Authorization signature invalid
+      // TODO: Add to language files.
       return 'The signature of the Authorization Response is invalid';
-    /* Content tree next failed - TODO add to language files */
+
     case 5:
+      // Content tree next failed
+      // TODO: Add to language files.
       return 'Content Tree Next failed';
-    /* Playback failed */
+
     case 6:
+      // Playback failed
       return 'Playback Error';
-    /* The asset is not encoded */
+
     case 7:
+      // The asset is not encoded
       return 'This video is not encoded for your device';
-    /* Internal error - TODO add to language files */
+
     case 8:
+      // Internal error
+      // TODO: Add to language files.
       return 'An internal error occurred';
-    /* Metadata response invalid */
+
     case 9:
+      // Metadata response invalid
       return 'Invalid Metadata';
-    /* Invalid authorization token */
+
     case 10:
+      // Invalid authorization token
       return 'Invalid Player Token';
-    /* Device limit has been reached */
+
     case 11:
+      // Device limit has been reached
       return 'Authorization Error';
-    /* Device binding failed */
+
     case 12:
+      // Device binding failed
       return 'Device binding failed';
-    /* Device id too long */
+
     case 13:
+      // Device id too long
       return 'Device ID is too long';
-    /* General DRM failure */
+
     case 14:
+      // General DRM failure
       return 'General error acquiring license';
-    /* DRM file download failure - TODO add to language files */
+
     case 15:
+      // DRM file download failure
+      // TODO: Add to language files.
       return 'Failed to download a required file during the DRM workflow';
-    /* DRM personalization failure - TODO add to language files */
+
     case 16:
+      // DRM personalization failure
+      // TODO: Add to language files.
       return 'Failed to complete device personalization during the DRM workflow';
-    /*  DRM rights server error - TODO add to language files */
+
     case 17:
+      // DRM rights server error
+      // TODO: Add to language files.
       return 'Failed to get rights for asset during the DRM workflow';
-    /* Invalid discovery parameter - TODO add to language files */
+
     case 18:
+      // Invalid discovery parameter
+      // TODO: Add to language files.
       return 'The expected discovery parameters are not provided';
-    /* Discovery network error - TODO add to language files */
+
     case 19:
+      // Discovery network error
+      // TODO: Add to language files.
       return 'A discovery network error occurred';
-    /* Discovery response failure - TODO add to language files */
+
     case 20:
+      // Discovery response failure
+      // TODO: Add to language files.
       return 'A discovery response error occurred';
-    /* No available streams - TODO add to language files */
+
     case 21:
+      // No available streams
+      // TODO: Add to language files.
       return 'No available streams';
-    /* Pcode mismatch - TODO add to language files */
+
     case 22:
+      // Pcode mismatch
+      // TODO: Add to language files.
       return 'The provided PCode does not match the embed code owner';
-    /* Download error - TODO add to language files */
+
     case 23:
+      // Download error
+      // TODO: Add to language files.
       return 'A download error occurred';
-    /* Conncurrent streams */
+
     case 24:
+      // Concurrent streams
       return 'You have exceeded the maximum number of concurrent streams';
-    /*  Advertising id failure - TODO add to language files */
+
     case 25:
+      //  Advertising id failure
+      // TODO: Add to language files.
       return 'Failed to return the advertising ID';
-    /* Discovery GET failure - TODO add to language files */
+
     case 26:
+      // Discovery GET failure
+      // TODO: Add to language files.
       return 'Failed to get discovery results';
-    /* Discovery POST failure - TODO add to language files */
+
     case 27:
+      // Discovery POST failure
+      // TODO: Add to language files.
       return 'Failed to post discovery pins';
-    /* Player format mismatch - TODO add to language files */
+
     case 28:
+      // Player format mismatch
+      // TODO: Add to language files.
       return 'Player and player content do not correspond';
-    /* Failed to create VR player  - TODO add to language files  */
+
     case 29:
+      // Failed to create VR player
+      // TODO: Add to language files.
       return 'Failed to create VR player';
-    /* Unknown error - TODO add to language files */
+
     case 30:
+      // Unknown error
+      // TODO: Add to language files.
       return 'An unknown error occurred';
-    /* GeoBlocking access denied - TODO add to language files */
+
     case 31:
+      // GeoBlocking access denied
+      // TODO: Add to language files.
       return 'Geo access denied';
-    /* Default to Unknown error */
+
     default:
+      // Default to Unknown error
       return 'An unknown error occurred';
   }
 };
 
-export const restrictSeekValueIfNeeded = (seekValue) => {
-  const value = Math.min(Math.max(VALUES.MIN_SKIP_VALUE, seekValue), VALUES.MAX_SKIP_VALUE);
-  return value;
-};
+export const restrictSeekValueIfNeeded = seekValue => (
+  Math.min(Math.max(VALUES.MIN_SKIP_VALUE, seekValue), VALUES.MAX_SKIP_VALUE)
+);

--- a/sdk/react/src/lib/utils.test.js
+++ b/sdk/react/src/lib/utils.test.js
@@ -1,40 +1,10 @@
-'use strict';
-
-jest.dontMock('./utils');
+// @flow
 
 import * as Utils from './utils';
+import localizableData from './__fixtures__/localizableData';
 
-describe('utils test suite', function () {
-
-  const localizableData = {
-    defaultLanguage: 'en',
-    en: {
-      'Learn More': 'Learn More',
-      'CLOSED CAPTION PREVIEW': 'CLOSED CAPTION PREVIEW',
-      'Sample Text': 'Sample Text',
-      'Ad': 'Ad',
-      'Skip Ad': 'Skip Ad',
-      'LIVE': 'LIVE',
-      'GO LIVE': 'GO LIVE',
-      'CC Options': 'CC Options',
-      'On': 'On',
-      'Off': 'Off',
-    },
-    es: {
-      'Learn More': 'Más información',
-      'CLOSED CAPTION PREVIEW': 'VISTA PRELIMINAR DE SUBTÍTULOS',
-      'Sample Text': 'Texto de muestra',
-      'Ad': 'Anuncio',
-      'Skip Ad': 'Omitir anuncio',
-      'LIVE': 'EN VIVO',
-      'GO LIVE': 'TRANSMITIR EN VIVO',
-      'CC Options': 'Opciones de subtitulado',
-      'On': 'Sí',
-      'Off': 'No',
-    },
-  };
-
-  it('tests localizedString() with edge cases', function () {
+describe('localizedString', () => {
+  it('tests localizedString() with edge cases', () => {
     const cases = [
       [null, null, null],
       [undefined, undefined, undefined],
@@ -42,81 +12,70 @@ describe('utils test suite', function () {
       [-12.12, null, {}],
       [{}, undefined, []],
     ];
-    for (let i = 0; i < cases.length; i++) {
-      const result = Utils.localizedString.apply(null, cases[i]);
-      expect(result)
-        .toBeNull();
+
+    for (let i = 0; i < cases.length; i += 1) {
+      const result = Utils.localizedString(null, cases[i]);
+
+      expect(result).toBeNull();
     }
   });
 
-  it('tests localizedString() with not found preferredLocale', function () {
-    const result = Utils.localizedString('not found', 'On', localizableData);
-    expect(result)
-      .toBe('On');
+  it('tests localizedString() with not found preferredLocale', () => {
+    let result = Utils.localizedString('not found', 'On', localizableData);
+    expect(result).toBe('On');
 
     result = Utils.localizedString('not found', 'NotFound', localizableData);
-    expect(result)
-      .toBe('NotFound');
+    expect(result).toBe('NotFound');
 
     result = Utils.localizedString(null, 'NotFound', localizableData);
-    expect(result)
-      .toBe('NotFound');
+    expect(result).toBe('NotFound');
 
     result = Utils.localizedString(undefined, 'NotFound', localizableData);
-    expect(result)
-      .toBe('NotFound');
+    expect(result).toBe('NotFound');
   });
 
-  it('tests localizedString() with not found stringId', function () {
-    const result = Utils.localizedString('es', 'I do not have a key', localizableData);
-    expect(result)
-      .toBe('I do not have a key');
+  it('tests localizedString() with not found stringId', () => {
+    let result = Utils.localizedString('es', 'I do not have a key', localizableData);
+    expect(result).toBe('I do not have a key');
 
     result = Utils.localizedString('es', null, localizableData);
-    expect(result)
-      .toBeNull();
+    expect(result).toBeNull();
 
     result = Utils.localizedString('es', undefined, localizableData);
-    expect(result)
-      .toBeNull();
+    expect(result).toBeNull();
   });
 
-  it('tests localizedString() without localizableStrings', function () {
-    const result = Utils.localizedString('es', 'LIVE', {});
-    expect(result)
-      .toBe('LIVE');
+  it('tests localizedString() without localizableStrings', () => {
+    let result = Utils.localizedString('es', 'LIVE', {});
+    expect(result).toBe('LIVE');
 
     result = Utils.localizedString('es', 'LIVE', null);
-    expect(result)
-      .toBe('LIVE');
+    expect(result).toBe('LIVE');
 
     result = Utils.localizedString('es', 'LIVE', undefined);
-    expect(result)
-      .toBe('LIVE');
+    expect(result).toBe('LIVE');
   });
 
-  it('tests localizedString() uses preferredLocale', function () {
-    const result = Utils.localizedString('es', 'Sample Text', localizableData);
-    expect(result)
-      .toBe('Texto de muestra');
+  it('tests localizedString() uses preferredLocale', () => {
+    let result = Utils.localizedString('es', 'Sample Text', localizableData);
+    expect(result).toBe('Texto de muestra');
 
-    const result = Utils.localizedString('en', 'Sample Text', localizableData);
-    expect(result)
-      .toBe('Sample Text');
+    result = Utils.localizedString('en', 'Sample Text', localizableData);
+    expect(result).toBe('Sample Text');
   });
 
-  it('tests localizedString() uses localizableData defaultLanguage', function () {
-    const result = Utils.localizedString('fr', 'Ad', localizableData);
-    expect(result)
-      .toBe('Ad');
+  it('tests localizedString() uses localizableData defaultLanguage', () => {
+    let result = Utils.localizedString('fr', 'Ad', localizableData);
+    expect(result).toBe('Ad');
 
-    localizableData['defaultLanguage'] = 'es';
-    const result = Utils.localizedString('kr', 'Ad', localizableData);
-    expect(result)
-      .toBe('Anuncio');
+    localizableData.defaultLanguage = 'es';
+    result = Utils.localizedString('kr', 'Ad', localizableData);
+    expect(result).toBe('Anuncio');
   });
+});
 
-  it('tests shouldShowLandscape() with invalid arguments', function () {
+describe('shouldShowLandscape', () => {
+  it('tests shouldShowLandscape() with invalid arguments', () => {
     const cases = [
       [null, null],
       [undefined, undefined],
@@ -125,36 +84,30 @@ describe('utils test suite', function () {
       ['number', ['x']],
     ];
 
-    for (let i = 0; i < cases.length; i++) {
-      const result = Utils.shouldShowLandscape.apply(null, cases[i]);
-      expect(result)
-        .toBeFalsy();
+    for (let i = 0; i < cases.length; i += 1) {
+      const result = Utils.shouldShowLandscape(null, cases[i]);
+
+      expect(result).toBeFalsy();
     }
   });
 
-  it('tests shouldShowLandscape() with valid arguments', function () {
-    const result = Utils.shouldShowLandscape(-12, -14);
-    expect(result)
-      .toBeFalsy();
+  it('tests shouldShowLandscape() with valid arguments', () => {
+    let result = Utils.shouldShowLandscape(-12, -14);
+    expect(result).toBeFalsy();
 
     result = Utils.shouldShowLandscape(0, 0);
-    expect(result)
-      .toBeFalsy();
+    expect(result).toBeFalsy();
 
     result = Utils.shouldShowLandscape(100, 101);
-    expect(result)
-      .toBeFalsy();
+    expect(result).toBeFalsy();
 
     result = Utils.shouldShowLandscape(102, 101);
-    expect(result)
-      .toBeTruthy();
+    expect(result).toBeTruthy();
 
     result = Utils.shouldShowLandscape(1280, 800);
-    expect(result)
-      .toBeTruthy();
+    expect(result).toBeTruthy();
 
     result = Utils.shouldShowLandscape(800, 1280);
-    expect(result)
-      .toBeFalsy();
+    expect(result).toBeFalsy();
   });
 });

--- a/sdk/react/src/shared/BottomOverlay/BottomOverlay.js
+++ b/sdk/react/src/shared/BottomOverlay/BottomOverlay.js
@@ -6,7 +6,7 @@ import {
 } from 'react-native';
 import type AnimatedValue from 'react-native/Libraries/Animated/src/nodes/AnimatedValue';
 
-import AccessibilityUtils from '../../lib/accessibility';
+import * as Accessibility from '../../lib/accessibility';
 import ProgressBar from '../ProgressBar';
 import {
   ANNOUNCER_TYPES,
@@ -318,7 +318,7 @@ export default class BottomOverlay extends React.Component<Props, State> {
     if (Platform.OS === 'android') {
       const playedPercent = this.touchPercent(pageX);
       const currentPercent = parseInt(playedPercent * 100, 10);
-      const announcingLabel = AccessibilityUtils.createAccessibilityAnnouncers(ANNOUNCER_TYPES.MOVING, currentPercent);
+      const announcingLabel = Accessibility.createAccessibilityAnnouncers(ANNOUNCER_TYPES.MOVING, currentPercent);
       const currentAnnouncing = new Date().getTime();
 
       if (previousAnnouncing === 0 || currentAnnouncing - previousAnnouncing > accessibilityDelay) {
@@ -351,7 +351,7 @@ export default class BottomOverlay extends React.Component<Props, State> {
     if (Platform.OS === 'android') {
       const playedPercent = this.touchPercent(pageX);
       const currentPercent = parseInt(playedPercent * 100, 10);
-      const announcingLabel = AccessibilityUtils.createAccessibilityAnnouncers(ANNOUNCER_TYPES.MOVED, currentPercent);
+      const announcingLabel = Accessibility.createAccessibilityAnnouncers(ANNOUNCER_TYPES.MOVED, currentPercent);
 
       AndroidAccessibility.announce(announcingLabel);
       previousAnnouncing = 0;

--- a/sdk/react/src/shared/BottomOverlay/BottomOverlay.js
+++ b/sdk/react/src/shared/BottomOverlay/BottomOverlay.js
@@ -18,7 +18,7 @@ import {
 } from '../../constants';
 import ControlBar from './ControlBar';
 import Log from '../../lib/log';
-import ResponsiveDesignManager from '../../lib/responsiveMultiplier';
+import responsiveMultiplier from '../../lib/responsiveMultiplier';
 import styles from './BottomOverlay.styles';
 import MarkersContainer from './MarkersContainer';
 import MarkersProgressBarOverlayContainer from './MarkersProgressBarOverlayContainer';
@@ -107,7 +107,7 @@ export default class BottomOverlay extends React.Component<Props, State> {
       accessibilityEnabled: false,
       cachedPlayhead: -1,
       height: new Animated.Value(props.isShow
-        ? ResponsiveDesignManager.makeResponsiveMultiplier(props.width, UI_SIZES.CONTROLBAR_HEIGHT) : 0),
+        ? responsiveMultiplier(props.width, UI_SIZES.CONTROLBAR_HEIGHT) : 0),
       markersContainerHeight: new Animated.Value(props.isShow ? MARKERS_SIZES.CONTAINER_HEIGHT : 0),
       opacity: new Animated.Value(props.isShow ? 1 : 0),
       touch: false,
@@ -166,12 +166,12 @@ export default class BottomOverlay extends React.Component<Props, State> {
     const { height, markersContainerHeight, opacity } = this.state;
 
     if (prevProps.width !== width && isShow) {
-      height.setValue(ResponsiveDesignManager.makeResponsiveMultiplier(width, UI_SIZES.CONTROLBAR_HEIGHT));
+      height.setValue(responsiveMultiplier(width, UI_SIZES.CONTROLBAR_HEIGHT));
       markersContainerHeight.setValue(MARKERS_SIZES.CONTAINER_HEIGHT);
     }
 
     if (prevProps.isShow !== isShow) {
-      height.setValue(isShow ? 1 : ResponsiveDesignManager.makeResponsiveMultiplier(width, UI_SIZES.CONTROLBAR_HEIGHT));
+      height.setValue(isShow ? 1 : responsiveMultiplier(width, UI_SIZES.CONTROLBAR_HEIGHT));
       opacity.setValue(isShow ? 0 : 1);
       markersContainerHeight.setValue(isShow ? 0 : MARKERS_SIZES.CONTAINER_HEIGHT);
 
@@ -184,7 +184,7 @@ export default class BottomOverlay extends React.Component<Props, State> {
         Animated.timing(height, {
           delay: 0,
           duration: 500,
-          toValue: (isShow ? ResponsiveDesignManager.makeResponsiveMultiplier(width, UI_SIZES.CONTROLBAR_HEIGHT) : 1),
+          toValue: (isShow ? responsiveMultiplier(width, UI_SIZES.CONTROLBAR_HEIGHT) : 1),
         }),
         Animated.timing(markersContainerHeight, {
           delay: 0,
@@ -292,7 +292,7 @@ export default class BottomOverlay extends React.Component<Props, State> {
 
     handleControlsTouch();
 
-    const touchableDistance = ResponsiveDesignManager.makeResponsiveMultiplier(width, scrubTouchableDistance);
+    const touchableDistance = responsiveMultiplier(width, scrubTouchableDistance);
 
     // Accessing Animated.Value provides number, so it can be used in arithmetic operations.
     // $FlowFixMe

--- a/sdk/react/src/shared/BottomOverlay/BottomOverlay.js
+++ b/sdk/react/src/shared/BottomOverlay/BottomOverlay.js
@@ -17,7 +17,7 @@ import {
   VIEW_NAMES,
 } from '../../constants';
 import ControlBar from './ControlBar';
-import Log from '../../lib/log';
+import * as Log from '../../lib/log';
 import responsiveMultiplier from '../../lib/responsiveMultiplier';
 import styles from './BottomOverlay.styles';
 import MarkersContainer from './MarkersContainer';

--- a/sdk/react/src/shared/BottomOverlay/ControlBar/ControlBar.js
+++ b/sdk/react/src/shared/BottomOverlay/ControlBar/ControlBar.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import { NativeModules, Platform, View } from 'react-native';
 
 import { ACCESSIBILITY_ANNOUNCERS, BUTTON_NAMES, UI_SIZES } from '../../../constants';
-import CollapsingBarUtils from '../../../lib/collapser';
+import { collapse } from '../../../lib/collapser';
 import Log from '../../../lib/log';
 import ResponsiveDesignManager from '../../../lib/responsiveMultiplier';
 import * as Utils from '../../../lib/utils';
@@ -295,7 +295,7 @@ export default class ControlBar extends Component {
 
     this.props.config.buttons.forEach(_isVisible, this);
 
-    const itemCollapsingResults = CollapsingBarUtils.collapse(this.props.width, this.props.config.buttons);
+    const itemCollapsingResults = collapse(this.props.width, this.props.config.buttons);
 
     function pushControl(item) {
       controlBarWidgets.push(item);

--- a/sdk/react/src/shared/BottomOverlay/ControlBar/ControlBar.js
+++ b/sdk/react/src/shared/BottomOverlay/ControlBar/ControlBar.js
@@ -5,7 +5,7 @@ import { NativeModules, Platform, View } from 'react-native';
 import { ACCESSIBILITY_ANNOUNCERS, BUTTON_NAMES, UI_SIZES } from '../../../constants';
 import { collapse } from '../../../lib/collapser';
 import Log from '../../../lib/log';
-import ResponsiveDesignManager from '../../../lib/responsiveMultiplier';
+import responsiveMultiplier from '../../../lib/responsiveMultiplier';
 import * as Utils from '../../../lib/utils';
 import ControlBarWidget from '../../ControlBarWidgets';
 
@@ -143,8 +143,8 @@ export default class ControlBar extends Component {
     const {
       config, live, width, height, showAudioAndCCButton,
     } = this.props;
-    const iconFontSize = ResponsiveDesignManager.makeResponsiveMultiplier(width, UI_SIZES.CONTROLBAR_ICONSIZE);
-    const labelFontSize = ResponsiveDesignManager.makeResponsiveMultiplier(width, UI_SIZES.CONTROLBAR_LABELSIZE);
+    const iconFontSize = responsiveMultiplier(width, UI_SIZES.CONTROLBAR_ICONSIZE);
+    const labelFontSize = responsiveMultiplier(width, UI_SIZES.CONTROLBAR_LABELSIZE);
     const waterMarkName = Platform.select({
       ios: config.controlBar.logo.imageResource.iosResource,
       android: config.controlBar.logo.imageResource.androidResource,

--- a/sdk/react/src/shared/BottomOverlay/ControlBar/ControlBar.js
+++ b/sdk/react/src/shared/BottomOverlay/ControlBar/ControlBar.js
@@ -4,7 +4,7 @@ import { NativeModules, Platform, View } from 'react-native';
 
 import { ACCESSIBILITY_ANNOUNCERS, BUTTON_NAMES, UI_SIZES } from '../../../constants';
 import { collapse } from '../../../lib/collapser';
-import Log from '../../../lib/log';
+import * as Log from '../../../lib/log';
 import responsiveMultiplier from '../../../lib/responsiveMultiplier';
 import * as Utils from '../../../lib/utils';
 import ControlBarWidget from '../../ControlBarWidgets';

--- a/sdk/react/src/shared/ControlBarWidgets/ControlBarWidgets.js
+++ b/sdk/react/src/shared/ControlBarWidgets/ControlBarWidgets.js
@@ -5,7 +5,7 @@ import {
 } from 'react-native';
 
 import { BUTTON_NAMES, STRING_CONSTANTS, VIEW_ACCESSIBILITY_NAMES } from '../../constants';
-import AccessibilityUtils from '../../lib/accessibility';
+import * as Accessibility from '../../lib/accessibility';
 import * as Utils from '../../lib/utils';
 import SkipButton from '../SkipButton';
 import VolumeView from './VolumeView';
@@ -358,7 +358,7 @@ export default class ControlBarWidgets extends Component {
 
     // Create accessibility label for selected playback speed rate button
     const playbackSpeedRateWithoutPostfix = options.selectedPlaybackSpeedRate.slice(0, -1);
-    const selectedPlaybackSpeedAccessiblityLabel = AccessibilityUtils.createAccessibilityLabelForSelectedObject(
+    const selectedPlaybackSpeedAccessiblityLabel = Accessibility.createAccessibilityLabelForSelectedObject(
       playbackSpeedRateWithoutPostfix,
     );
     const accessibilityLabel = VIEW_ACCESSIBILITY_NAMES.PLAYBACK_SPEED_BUTTON + selectedPlaybackSpeedAccessiblityLabel;

--- a/sdk/react/src/shared/ItemSelectionScrollView/ItemSelectionScrollView.js
+++ b/sdk/react/src/shared/ItemSelectionScrollView/ItemSelectionScrollView.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import { Text, TouchableHighlight, View } from 'react-native';
 
 import ItemSelectionList from './ItemSelectionList';
-import AccessibilityUtils from '../../lib/accessibility';
+import * as Accessibility from '../../lib/accessibility';
 import * as Utils from '../../lib/utils';
 
 import styles from './ItemSelectionScrollView.styles';
@@ -32,7 +32,7 @@ export default class ItemSelectionScrollView extends Component {
     const buttonStyle = isSelectedItem ? styles.selectedButton : styles.button;
     const textStyle = isSelectedItem ? styles.selectedButtonText : styles.buttonText;
     const checkmarkIcon = isSelectedItem ? this.props.config.icons.selected.fontString : '';
-    const accessibilityString = AccessibilityUtils.createAccessibilityLabelForCell(this.props.cellType, item);
+    const accessibilityString = Accessibility.createAccessibilityLabelForCell(this.props.cellType, item);
 
     return (
       <TouchableHighlight

--- a/sdk/react/src/shared/ProgressBar/ProgressBar.js
+++ b/sdk/react/src/shared/ProgressBar/ProgressBar.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import { View } from 'react-native';
 
 import { VIEW_NAMES } from '../../constants';
-import Log from '../../lib/log';
+import * as Log from '../../lib/log';
 
 import styles from './ProgressBar.styles';
 

--- a/sdk/react/src/shared/SkipButton/SkipButton.js
+++ b/sdk/react/src/shared/SkipButton/SkipButton.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import { Animated, TouchableHighlight } from 'react-native';
 
 import { STRING_CONSTANTS } from '../../constants';
-import AccessibilityUtils from '../../lib/accessibility';
+import * as Accessibility from '../../lib/accessibility';
 
 import styles from './SkipButton.styles';
 
@@ -34,7 +34,7 @@ export default class SkipButton extends Component {
     if (!this.props.visible) {
       return null;
     }
-    const accessibilityLabel = AccessibilityUtils.createAccessibilityForForwardButton(this.props.isForward,
+    const accessibilityLabel = Accessibility.createAccessibilityForForwardButton(this.props.isForward,
       this.props.timeValue, STRING_CONSTANTS.SECONDS);
     const position = {
       position: 'absolute',

--- a/sdk/react/src/shared/VideoViewPlayPause/VideoViewPlayPause.js
+++ b/sdk/react/src/shared/VideoViewPlayPause/VideoViewPlayPause.js
@@ -4,7 +4,7 @@ import { Animated, TouchableHighlight, View } from 'react-native';
 import timerForSkipButtons from 'react-native-timer';
 
 import { BUTTON_NAMES, VALUES } from '../../constants';
-import AccessibilityUtils from '../../lib/accessibility';
+import * as Accessibility from '../../lib/accessibility';
 import * as Utils from '../../lib/utils';
 import SkipButton from '../SkipButton';
 
@@ -118,7 +118,7 @@ export default class VideoViewPlayPause extends Component {
       width: this.props.buttonWidth * 2,
       height: this.props.buttonHeight * 2,
     };
-    const label = AccessibilityUtils.createAccessibilityForPlayPauseButton(name);
+    const label = Accessibility.createAccessibilityForPlayPauseButton(name);
 
     return (
       <TouchableHighlight

--- a/sdk/react/src/views/AdPlaybackScreen/AdBar/AdBar.js
+++ b/sdk/react/src/views/AdPlaybackScreen/AdBar/AdBar.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import { Text, TouchableHighlight, View } from 'react-native';
 
 import { BUTTON_NAMES } from '../../../constants';
-import Log from '../../../lib/log';
+import * as Log from '../../../lib/log';
 import * as Utils from '../../../lib/utils';
 
 import styles from './AdBar.styles';

--- a/sdk/react/src/views/AdPlaybackScreen/AdPlaybackScreen.js
+++ b/sdk/react/src/views/AdPlaybackScreen/AdPlaybackScreen.js
@@ -5,7 +5,7 @@ import { Image, TouchableHighlight, View } from 'react-native';
 import AdBar from './AdBar';
 import { AUTOHIDE_DELAY, UI_SIZES, VALUES } from '../../constants';
 import Log from '../../lib/log';
-import ResponsiveDesignManager from '../../lib/responsiveMultiplier';
+import responsiveMultiplier from '../../lib/responsiveMultiplier';
 import * as Utils from '../../lib/utils';
 import BottomOverlay from '../../shared/BottomOverlay';
 import VideoViewPlayPause from '../../shared/VideoViewPlayPause';
@@ -154,7 +154,7 @@ export default class AdPlaybackScreen extends Component {
   );
 
   _renderPlayPause = (show) => {
-    const iconFontSize = ResponsiveDesignManager.makeResponsiveMultiplier(this.props.width,
+    const iconFontSize = responsiveMultiplier(this.props.width,
       UI_SIZES.VIDEOVIEW_PLAYPAUSE);
     return (
       <VideoViewPlayPause

--- a/sdk/react/src/views/AdPlaybackScreen/AdPlaybackScreen.js
+++ b/sdk/react/src/views/AdPlaybackScreen/AdPlaybackScreen.js
@@ -4,7 +4,7 @@ import { Image, TouchableHighlight, View } from 'react-native';
 
 import AdBar from './AdBar';
 import { AUTOHIDE_DELAY, UI_SIZES, VALUES } from '../../constants';
-import Log from '../../lib/log';
+import * as Log from '../../lib/log';
 import responsiveMultiplier from '../../lib/responsiveMultiplier';
 import * as Utils from '../../lib/utils';
 import BottomOverlay from '../../shared/BottomOverlay';

--- a/sdk/react/src/views/AudioView/AudioView.js
+++ b/sdk/react/src/views/AudioView/AudioView.js
@@ -7,7 +7,7 @@ import timerForSkipButtons from 'react-native-timer';
 
 import { BUTTON_NAMES, UI_SIZES, VALUES } from '../../constants';
 import { collapse } from '../../lib/collapser';
-import Log from '../../lib/log';
+import * as Log from '../../lib/log';
 import responsiveMultiplier from '../../lib/responsiveMultiplier';
 import * as Utils from '../../lib/utils';
 import ControlBarWidget from '../../shared/ControlBarWidgets';

--- a/sdk/react/src/views/AudioView/AudioView.js
+++ b/sdk/react/src/views/AudioView/AudioView.js
@@ -8,7 +8,7 @@ import timerForSkipButtons from 'react-native-timer';
 import { BUTTON_NAMES, UI_SIZES, VALUES } from '../../constants';
 import { collapse } from '../../lib/collapser';
 import Log from '../../lib/log';
-import ResponsiveDesignManager from '../../lib/responsiveMultiplier';
+import responsiveMultiplier from '../../lib/responsiveMultiplier';
 import * as Utils from '../../lib/utils';
 import ControlBarWidget from '../../shared/ControlBarWidgets';
 import ProgressBar from '../../shared/ProgressBar';
@@ -47,7 +47,7 @@ export default class AudioView extends Component {
     playing: false,
     skipCount: 0,
     height: new Animated.Value(
-      ResponsiveDesignManager.makeResponsiveMultiplier(this.props.width, UI_SIZES.CONTROLBAR_HEIGHT),
+      responsiveMultiplier(this.props.width, UI_SIZES.CONTROLBAR_HEIGHT),
     ),
     cachedPlayhead: -1,
     progressBarWidth: 0,
@@ -182,9 +182,9 @@ export default class AudioView extends Component {
 
   // MARK: - ControlBar
   _renderControlBar = () => {
-    const iconFontSize = ResponsiveDesignManager.makeResponsiveMultiplier(this.props.width,
+    const iconFontSize = responsiveMultiplier(this.props.width,
       UI_SIZES.CONTROLBAR_ICONSIZE);
-    const labelFontSize = ResponsiveDesignManager.makeResponsiveMultiplier(this.props.width,
+    const labelFontSize = responsiveMultiplier(this.props.width,
       UI_SIZES.CONTROLBAR_LABELSIZE);
 
     const controlBarWidgets = [];
@@ -382,7 +382,7 @@ export default class AudioView extends Component {
 
   handleTouchStart = (event) => {
     this.props.handlers.handleControlsTouch();
-    const touchableDistance = ResponsiveDesignManager.makeResponsiveMultiplier(this.state.progressBarWidth,
+    const touchableDistance = responsiveMultiplier(this.state.progressBarWidth,
       scrubTouchableDistance);
     if ((this.props.height - event.nativeEvent.locationY) < touchableDistance) {
       return;

--- a/sdk/react/src/views/AudioView/AudioView.js
+++ b/sdk/react/src/views/AudioView/AudioView.js
@@ -6,7 +6,7 @@ import {
 import timerForSkipButtons from 'react-native-timer';
 
 import { BUTTON_NAMES, UI_SIZES, VALUES } from '../../constants';
-import CollapsingBarUtils from '../../lib/collapser';
+import { collapse } from '../../lib/collapser';
 import Log from '../../lib/log';
 import ResponsiveDesignManager from '../../lib/responsiveMultiplier';
 import * as Utils from '../../lib/utils';
@@ -255,7 +255,7 @@ export default class AudioView extends Component {
       },
     };
 
-    const itemCollapsingResults = CollapsingBarUtils.collapse(this.props.width, this.props.config.buttons);
+    const itemCollapsingResults = collapse(this.props.width, this.props.config.buttons);
     for (let i = 0; i < itemCollapsingResults.fit.length; i++) {
       const widget = itemCollapsingResults.fit[i];
       const item = (

--- a/sdk/react/src/views/CastConnectedScreen/CastConnectedScreen.js
+++ b/sdk/react/src/views/CastConnectedScreen/CastConnectedScreen.js
@@ -6,7 +6,7 @@ import {
 
 import CastPlayPauseButtons from './CastPlayPauseButtons';
 import { BUTTON_NAMES, UI_SIZES, VALUES } from '../../constants';
-import ResponsiveDesignManager from '../../lib/responsiveMultiplier';
+import responsiveMultiplier from '../../lib/responsiveMultiplier';
 import * as Utils from '../../lib/utils';
 import BottomOverlay from '../../shared/BottomOverlay';
 
@@ -261,7 +261,7 @@ export default class CastConnectedScreen extends Component {
       play, previous, next, pause, forward, replay,
     } = config.icons;
 
-    const iconFontSize = ResponsiveDesignManager.makeResponsiveMultiplier(width, UI_SIZES.VIDEOVIEW_PLAYPAUSE);
+    const iconFontSize = responsiveMultiplier(width, UI_SIZES.VIDEOVIEW_PLAYPAUSE);
     const seekVisible = !config.live.forceDvrDisabled || !live;
     const notInLiveRegion = playhead <= duration * VALUES.LIVE_THRESHOLD;
     const icons = {

--- a/sdk/react/src/views/CastConnectedScreen/CastPlayPauseButtons/CastPlayPauseButtons.js
+++ b/sdk/react/src/views/CastConnectedScreen/CastPlayPauseButtons/CastPlayPauseButtons.js
@@ -6,7 +6,7 @@ import {
 import timerForSkipButtons from 'react-native-timer';
 
 import { BUTTON_NAMES, VALUES } from '../../../constants';
-import AccessibilityUtils from '../../../lib/accessibility';
+import * as Accessibility from '../../../lib/accessibility';
 import * as Utils from '../../../lib/utils';
 import SkipButton from '../../../shared/SkipButton';
 import SwitchButton from './SwitchButton';
@@ -159,7 +159,7 @@ export default class CastPlayPauseButtons extends Component {
       width: buttonWidth * 2,
       height: buttonHeight * 2,
     };
-    const label = AccessibilityUtils.createAccessibilityForPlayPauseButton(name);
+    const label = Accessibility.createAccessibilityForPlayPauseButton(name);
 
     return (
       <TouchableHighlight

--- a/sdk/react/src/views/CastConnectedScreen/CastPlayPauseButtons/SwitchButton/SwitchButton.js
+++ b/sdk/react/src/views/CastConnectedScreen/CastPlayPauseButtons/SwitchButton/SwitchButton.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import { Animated, TouchableHighlight } from 'react-native';
 
 import { STRING_CONSTANTS } from '../../../../constants';
-import AccessibilityUtils from '../../../../lib/accessibility';
+import * as Accessibility from '../../../../lib/accessibility';
 
 import styles from './SwitchButton.styles';
 
@@ -35,7 +35,7 @@ export default class SwitchButton extends Component {
     if (!visible) {
       return null;
     }
-    const accessibilityLabel = AccessibilityUtils
+    const accessibilityLabel = Accessibility
       .createAccessibilityForForwardButton(isForward, timeValue, STRING_CONSTANTS.SECONDS);
     const position = {
       position: 'absolute',

--- a/sdk/react/src/views/DiscoveryPanel/DiscoveryPanel.js
+++ b/sdk/react/src/views/DiscoveryPanel/DiscoveryPanel.js
@@ -12,7 +12,7 @@ import {
 } from 'react-native';
 
 import { BUTTON_NAMES, SCREEN_TYPES } from '../../constants';
-import Log from '../../lib/log';
+import * as Log from '../../lib/log';
 import * as Utils from '../../lib/utils';
 import ResponsiveList from './ResponsiveList';
 import CountdownViewAndroid from '../../shared/CountdownTimerAndroid';

--- a/sdk/react/src/views/EndScreen/EndScreen.js
+++ b/sdk/react/src/views/EndScreen/EndScreen.js
@@ -6,7 +6,7 @@ import {
 
 import { BUTTON_NAMES, UI_SIZES } from '../../constants';
 import InfoPanel from './InfoPanel';
-import Log from '../../lib/log';
+import * as Log from '../../lib/log';
 import responsiveMultiplier from '../../lib/responsiveMultiplier';
 import BottomOverlay from '../../shared/BottomOverlay';
 

--- a/sdk/react/src/views/EndScreen/EndScreen.js
+++ b/sdk/react/src/views/EndScreen/EndScreen.js
@@ -7,7 +7,7 @@ import {
 import { BUTTON_NAMES, UI_SIZES } from '../../constants';
 import InfoPanel from './InfoPanel';
 import Log from '../../lib/log';
-import ResponsiveDesignManager from '../../lib/responsiveMultiplier';
+import responsiveMultiplier from '../../lib/responsiveMultiplier';
 import BottomOverlay from '../../shared/BottomOverlay';
 
 import styles from './EndScreen.styles';
@@ -60,7 +60,7 @@ export default class EndScreen extends Component {
     const endScreenConfig = this.props.config.endScreen || {};
 
     const replayMarginBottom = !this.props.config.controlBar.enabled
-      ? ResponsiveDesignManager.makeResponsiveMultiplier(this.props.width, UI_SIZES.CONTROLBAR_HEIGHT) : 1;
+      ? responsiveMultiplier(this.props.width, UI_SIZES.CONTROLBAR_HEIGHT) : 1;
 
     const replayButtonLocation = styles.replayButtonCenter;
     let replayButton;
@@ -157,7 +157,7 @@ export default class EndScreen extends Component {
   }
 
   renderLoading() {
-    const loadingSize = ResponsiveDesignManager.makeResponsiveMultiplier(this.props.width, UI_SIZES.LOADING_ICON);
+    const loadingSize = responsiveMultiplier(this.props.width, UI_SIZES.LOADING_ICON);
     const scaleMultiplier = Platform.OS === 'android' ? 2 : 1;
     const topOffset = Math.round((this.props.height - loadingSize * scaleMultiplier) * 0.5);
     const leftOffset = Math.round((this.props.width - loadingSize * scaleMultiplier) * 0.5);

--- a/sdk/react/src/views/ErrorScreen/ErrorScreen.js
+++ b/sdk/react/src/views/ErrorScreen/ErrorScreen.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import { Text, TouchableHighlight, View } from 'react-native';
 
 import { BUTTON_NAMES, ERROR_MESSAGE, SAS_ERROR_CODES } from '../../constants';
-import Log from '../../lib/log';
+import * as Log from '../../lib/log';
 import * as Utils from '../../lib/utils';
 
 import styles from './ErrorScreen.styles';

--- a/sdk/react/src/views/MoreDetailsScreen/MoreDetailsScreen.js
+++ b/sdk/react/src/views/MoreDetailsScreen/MoreDetailsScreen.js
@@ -5,7 +5,7 @@ import {
 } from 'react-native';
 
 import { BUTTON_NAMES, ERROR_MESSAGE, SAS_ERROR_CODES } from '../../constants';
-import Log from '../../lib/log';
+import * as Log from '../../lib/log';
 import * as Utils from '../../lib/utils';
 import RectangularButton from '../../shared/RectangularButton';
 

--- a/sdk/react/src/views/MoreOptionScreen/MoreOptionScreen.js
+++ b/sdk/react/src/views/MoreOptionScreen/MoreOptionScreen.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import { Animated, View } from 'react-native';
 
 import { BUTTON_NAMES } from '../../constants';
-import CollapsingBarUtils from '../../lib/collapser';
+import { collapse, collapseForAudioOnly } from '../../lib/collapser';
 import Log from '../../lib/log';
 import RectangularButton from '../../shared/RectangularButton';
 
@@ -97,9 +97,9 @@ export default class MoreOptionScreen extends Component {
     let itemCollapsingResults;
 
     if (this.props.isAudioOnly) {
-      itemCollapsingResults = CollapsingBarUtils.collapseForAudioOnly(this.props.config.buttons);
+      itemCollapsingResults = collapseForAudioOnly(this.props.config.buttons);
     } else {
-      itemCollapsingResults = CollapsingBarUtils.collapse(this.props.config.controlBarWidth, this.props.config.buttons);
+      itemCollapsingResults = collapse(this.props.config.controlBarWidth, this.props.config.buttons);
     }
 
     const buttons = itemCollapsingResults.overflow;

--- a/sdk/react/src/views/MoreOptionScreen/MoreOptionScreen.js
+++ b/sdk/react/src/views/MoreOptionScreen/MoreOptionScreen.js
@@ -4,7 +4,7 @@ import { Animated, View } from 'react-native';
 
 import { BUTTON_NAMES } from '../../constants';
 import { collapse, collapseForAudioOnly } from '../../lib/collapser';
-import Log from '../../lib/log';
+import * as Log from '../../lib/log';
 import RectangularButton from '../../shared/RectangularButton';
 
 import styles from './MoreOptionScreen.styles';

--- a/sdk/react/src/views/StartScreen/StartScreen.js
+++ b/sdk/react/src/views/StartScreen/StartScreen.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import { Image, Text, View } from 'react-native';
 
 import { BUTTON_NAMES, IMG_URLS, UI_SIZES } from '../../constants';
-import ResponsiveDesignManager from '../../lib/responsiveMultiplier';
+import responsiveMultiplier from '../../lib/responsiveMultiplier';
 import VideoViewPlayPause from '../../shared/VideoViewPlayPause';
 
 import styles from './StartScreen.styles';
@@ -27,7 +27,7 @@ export default class StartScreen extends Component {
 
   // Gets the play button based on the current config settings
   getPlayButton = () => {
-    const iconFontSize = ResponsiveDesignManager.makeResponsiveMultiplier(this.props.width,
+    const iconFontSize = responsiveMultiplier(this.props.width,
       UI_SIZES.VIDEOVIEW_PLAYPAUSE);
 
     if (this.props.config.startScreen.showPlayButton) {

--- a/sdk/react/src/views/VideoView/VideoView.js
+++ b/sdk/react/src/views/VideoView/VideoView.js
@@ -7,7 +7,7 @@ import {
 import {
   AUTOHIDE_DELAY, BUTTON_NAMES, UI_SIZES, VALUES,
 } from '../../constants';
-import Log from '../../lib/log';
+import * as Log from '../../lib/log';
 import responsiveMultiplier from '../../lib/responsiveMultiplier';
 import * as Utils from '../../lib/utils';
 import BottomOverlay from '../../shared/BottomOverlay';

--- a/sdk/react/src/views/VideoView/VideoView.js
+++ b/sdk/react/src/views/VideoView/VideoView.js
@@ -8,7 +8,7 @@ import {
   AUTOHIDE_DELAY, BUTTON_NAMES, UI_SIZES, VALUES,
 } from '../../constants';
 import Log from '../../lib/log';
-import ResponsiveDesignManager from '../../lib/responsiveMultiplier';
+import responsiveMultiplier from '../../lib/responsiveMultiplier';
 import * as Utils from '../../lib/utils';
 import BottomOverlay from '../../shared/BottomOverlay';
 import VideoViewPlayPause from '../../shared/VideoViewPlayPause';
@@ -180,7 +180,7 @@ export default class VideoView extends Component {
   );
 
   _renderBottom = () => {
-    const VideoWaterMarkSize = ResponsiveDesignManager.makeResponsiveMultiplier(UI_SIZES.VIDEOWATERMARK,
+    const VideoWaterMarkSize = responsiveMultiplier(UI_SIZES.VIDEOWATERMARK,
       UI_SIZES.VIDEOWATERMARK);
     const waterMarkName = Platform.select({
       ios: this.props.config.general.watermark.imageResource.iosResource,
@@ -261,7 +261,7 @@ export default class VideoView extends Component {
   };
 
   _renderPlayPause = (show) => {
-    const iconFontSize = ResponsiveDesignManager.makeResponsiveMultiplier(this.props.width,
+    const iconFontSize = responsiveMultiplier(this.props.width,
       UI_SIZES.VIDEOVIEW_PLAYPAUSE);
     const seekVisible = !this.props.config.live.forceDvrDisabled || !this.props.live;
     const notInLiveRegion = this.props.playhead <= this.props.duration * VALUES.LIVE_THRESHOLD;
@@ -390,7 +390,7 @@ export default class VideoView extends Component {
   };
 
   _renderLoading = () => {
-    const loadingSize = ResponsiveDesignManager.makeResponsiveMultiplier(this.props.width, UI_SIZES.LOADING_ICON);
+    const loadingSize = responsiveMultiplier(this.props.width, UI_SIZES.LOADING_ICON);
     const scaleMultiplier = Platform.OS === 'android' ? 2 : 1;
     const topOffset = Math.round((this.props.height - loadingSize * scaleMultiplier) * 0.5);
     const leftOffset = Math.round((this.props.width - loadingSize * scaleMultiplier) * 0.5);


### PR DESCRIPTION
- ESLint errors fixed
- No business logic changed
- All tests are runnable now
- Tests actualized except one for `collapser`, I created a separate ticket for that (PLAYER-5503)
- `// @flow` comments are added as a preparation for further coverage
- Dead code removed
- `accessibility` and `log` now export functions instead of classes to remove unnecessary syntax sugar and ease process of searching for dead code
- `responsiveMultiplier` now exports one function by default as no other functions are used anywhere in the code
- In files located not in the `lib` dir only imports has been changed