### PR TITLE
[PLAYER-5551] Get rid of android-jsc. Soloader ver is updated to 0.6.0

### DIFF
--- a/sdk/android/build.gradle
+++ b/sdk/android/build.gradle
@@ -27,11 +27,10 @@ buildscript {
         // react-native dependencies
         inferAnnotationVersion = '0.11.2'
         frescoVersion = '1.10.0'
-        soloaderVersion = '0.5.1'
+        soloaderVersion = '0.6.0'
         findbugsVersion = '3.0.2'
         okhttpVersion = '3.12.1'
         okioVersion = '1.15.0'
-        androidJscVersion = 'r174650'
     }
 
     repositories {

--- a/sdk/android/skin/build.gradle
+++ b/sdk/android/skin/build.gradle
@@ -160,6 +160,5 @@ dependencies {
     implementation "com.squareup.okhttp3:okhttp:$rootProject.okhttpVersion"
     implementation "com.squareup.okhttp3:okhttp-urlconnection:$rootProject.okhttpVersion"
     implementation "com.squareup.okio:okio:$rootProject.okioVersion"
-    implementation "org.webkit:android-jsc:$rootProject.androidJscVersion"
     implementation(group:'com.facebook', name:'react-native', version:'0.59.4', ext:'aar')
 }


### PR DESCRIPTION
Basically, facebook ReactNative lib contains the other version of android-jsc lib that was referenced to another dependent library version **libc++_shared.so.** 
The old version of android-jsc [lib](https://github.com/facebook/android-jsc)  has the following dependency: **libgnustl_shared.so**