### PR TITLE
[PLAYER-5549] Playback ends abruptly once the ad starts playing

### DIFF
--- a/sdk/react/src/shared/BottomOverlay/ControlBar/ControlBar.js
+++ b/sdk/react/src/shared/BottomOverlay/ControlBar/ControlBar.js
@@ -162,7 +162,7 @@ export default class ControlBar extends Component {
     } else {
       liveCircle = null;
     }
-    const castEnabled = config.castControls.enabled;
+    const castEnabled = config.castControls ? config.castControls.enabled : false;
     const color = this.props.inCastMode ? config.castControls.iconStyle.active.color : config.castControls.iconStyle.inactive.color;
     const castIcon = this.props.inCastMode ? config.icons['chromecast-connected'] : config.icons['chromecast-disconnected'];
     const controlBarWidgets = [];


### PR DESCRIPTION
This crash issue was caused because castControls object does not always exist in config. 

Solution consists in adding a little check :) 