### PR TITLE
[PLAYER-5549] Playback ends abruptly once the ad starts playing

### DIFF
--- a/sdk/react/src/shared/BottomOverlay/ControlBar/ControlBar.js
+++ b/sdk/react/src/shared/BottomOverlay/ControlBar/ControlBar.js
@@ -162,13 +162,10 @@ export default class ControlBar extends Component {
     } else {
       liveCircle = null;
     }
-    const castEnabled = config.castControls.enabled;
-    const color = this.props.inCastMode ? config.castControls.iconStyle.active.color : config.castControls.iconStyle.inactive.color;
-    const castIcon = this.props.inCastMode ? config.icons['chromecast-connected'] : config.icons['chromecast-disconnected'];
+
     const controlBarWidgets = [];
 
-
-    const widgetOptions = {
+    let widgetOptions = {
       playPause: {
         onPress: this.onPlayPausePress,
         style: [styles.icon, { fontSize: iconFontSize }, config.controlBar.iconStyle.active],
@@ -224,13 +221,6 @@ export default class ControlBar extends Component {
         style: [styles.icon, { fontSize: iconFontSize }, config.controlBar.iconStyle.active],
         icon: config.icons.ellipsis,
       },
-      chromecast: {
-        onPress: this.onCastPress,
-        iconTouchableStyle: styles.iconTouchable,
-        style: [styles.icon, { fontSize: iconFontSize }, config.controlBar.iconStyle.active, { color }],
-        icon: castIcon,
-        enabled: castEnabled,
-      },
       discovery: {
         onPress: this.onDiscoveryPress,
         iconTouchableStyle: styles.iconTouchable,
@@ -270,6 +260,25 @@ export default class ControlBar extends Component {
         enabled: this.props.showPlaybackSpeedButton,
       },
     };
+
+    // Adding castControls validation because we don't use chromecast in admode
+    // When instantiated from BottomOverlay/AdPlaybackScreen castControls object is not available
+    if (config.castControls) {
+      const castEnabled = config.castControls.enabled;
+      const color = this.props.inCastMode ? config.castControls.iconStyle.active.color : config.castControls.iconStyle.inactive.color;
+      const castIcon = this.props.inCastMode ? config.icons['chromecast-connected'] : config.icons['chromecast-disconnected'];
+
+      const chromecast = {
+        chromecast: {
+          onPress: this.onCastPress,
+          iconTouchableStyle: styles.iconTouchable,
+          style: [styles.icon, { fontSize: iconFontSize }, config.controlBar.iconStyle.active, { color }],
+          icon: castIcon,
+          enabled: castEnabled
+        }
+      };
+      Object.assign(widgetOptions, chromecast);
+    }
 
     function _isVisible(item) {
       let visible = true;

--- a/sdk/react/src/shared/ControlBarWidgets/ControlBarWidgets.js
+++ b/sdk/react/src/shared/ControlBarWidgets/ControlBarWidgets.js
@@ -226,10 +226,10 @@ export default class ControlBarWidgets extends Component {
   };
 
   castWidget = (options) => {
-    const fontFamilyStyle = { fontFamily: options.icon.fontFamilyName };
-    if (!options.enabled || options.enabled === undefined) {
+    if (!options || !options.enabled || options.enabled === undefined) {
       return null;
     }
+    const fontFamilyStyle = { fontFamily: options.icon.fontFamilyName };
     return (
       <TouchableHighlight
         testID={BUTTON_NAMES.CAST}


### PR DESCRIPTION
Adding validation on ad mode. CastControls object in config is not available when an ad will play and that was causing crashes.