### PR TITLE
[PLAYER-5544] App gets crashed when Clicked on the “Previous/Next Video” icon

### DIFF
--- a/sdk/iOS/OoyalaSkinSDK/React/OOReactSkinBridgeModuleMain.m
+++ b/sdk/iOS/OoyalaSkinSDK/React/OOReactSkinBridgeModuleMain.m
@@ -151,7 +151,7 @@ RCT_EXPORT_METHOD(onPress:(NSDictionary *)parameters) {
 RCT_EXPORT_METHOD(onSwitch:(NSDictionary *)params) {
   BOOL isForward = [params[directionKey] boolValue];
   if (isForward) {
-    [self.skinModelDelegate handleSwitchNext];
+    [self.skinModelDelegate handleUpNextClick];
   } else {
     [self.skinModelDelegate handleSwitchPrevious];
   }

--- a/sdk/iOS/OoyalaSkinSDK/React/OOReactSkinModel.h
+++ b/sdk/iOS/OoyalaSkinSDK/React/OOReactSkinModel.h
@@ -76,7 +76,6 @@ extern NSString * _Nonnull const isPipButtonVisibleKey;
 - (void)handleCastDeviceSelected:(nonnull NSString *)deviceId;
 - (void)handleCastDisconnect;
 - (void)handleSwitchPrevious;
-- (void)handleSwitchNext;
 - (void)onVisibilityControlsChanged:(BOOL)isVisible;
 
 @end

--- a/sdk/iOS/OoyalaSkinSDK/React/OOReactSkinModel.m
+++ b/sdk/iOS/OoyalaSkinSDK/React/OOReactSkinModel.m
@@ -416,10 +416,6 @@ NSString *const isPipButtonVisibleKey  = @"isPipButtonVisible";
   [self.player previousVideo];
 }
 
-- (void)handleSwitchNext {
-  [self.player nextVideo];
-}
-
 - (void)onVisibilityControlsChanged:(BOOL)isVisible {
   [self sendEventWithName:visibilityControlsChanged
                      body:@{visibilityControlsKey: @(isVisible)}];

--- a/sdk/react/src/ViewsRenderer.js
+++ b/sdk/react/src/ViewsRenderer.js
@@ -192,6 +192,7 @@ export default class ViewsRenderer {
         inCastMode={this.skin.state.inCastMode}
         previewUrl={this.skin.state.previewUrl}
         markers={this.skin.state.markers}
+        hasNextVideo={this.core.shouldShowDiscoveryEndscreen()}
       />
     );
   }

--- a/sdk/react/src/views/CastConnectedScreen/CastConnectedScreen.js
+++ b/sdk/react/src/views/CastConnectedScreen/CastConnectedScreen.js
@@ -55,6 +55,7 @@ export default class CastConnectedScreen extends Component {
     inCastMode: PropTypes.bool.isRequired,
     previewUrl: PropTypes.string.isRequired,
     markers: PropTypes.array.isRequired,
+    hasNextVideo: PropTypes.bool.isRequired,
   };
 
   componentDidMount() {
@@ -264,7 +265,7 @@ export default class CastConnectedScreen extends Component {
   renderCastPlayPause() {
     const { props } = this;
     const {
-      width, height, config, live, playhead, duration, rate, playing, loading,
+      width, height, config, live, playhead, duration, rate, playing, loading, hasNextVideo
     } = props;
     const {
       play, previous, next, pause, forward, replay,
@@ -325,6 +326,7 @@ export default class CastConnectedScreen extends Component {
         rate={rate}
         playing={playing}
         loading={loading}
+        hasNextVideo={hasNextVideo}
       />
     );
   }

--- a/sdk/react/src/views/CastConnectedScreen/CastPlayPauseButtons/CastPlayPauseButtons.js
+++ b/sdk/react/src/views/CastConnectedScreen/CastPlayPauseButtons/CastPlayPauseButtons.js
@@ -47,7 +47,8 @@ export default class CastPlayPauseButtons extends React.Component {
     playing: PropTypes.bool.isRequired,
     loading: PropTypes.bool.isRequired,
     initialPlay: PropTypes.bool.isRequired,
-    config: PropTypes.object.isRequired
+    config: PropTypes.object.isRequired,
+    hasNextVideo: PropTypes.bool.isRequired
   };
 
   state = {
@@ -273,7 +274,7 @@ export default class CastPlayPauseButtons extends React.Component {
   // Gets the play button based on the current config settings
   render() {
     const {
-      frameHeight, buttonHeight, frameWidth, buttonWidth, showButton, config,
+      frameHeight, buttonHeight, frameWidth, buttonWidth, showButton, config, hasNextVideo
     } = this.props;
     const {
       previousVideo, nextVideo, skipBackward, skipForward,
@@ -281,7 +282,7 @@ export default class CastPlayPauseButtons extends React.Component {
     const seekButtonScale = 0.5;
     const playPauseButton = this.renderPlayPauseButton();
     const previousButton = this.renderSwitchButton(PREVIOUS, seekButtonScale, previousVideo.enabled);
-    const nextButton = this.renderSwitchButton(NEXT, seekButtonScale, nextVideo.enabled);
+    const nextButton = this.renderSwitchButton(NEXT, seekButtonScale, (nextVideo.enabled && hasNextVideo));
     const backwardButton = this.renderSeekButton(BACKWARD, seekButtonScale, skipBackward.enabled);
     const forwardButton = this.renderSeekButton(FORWARD, seekButtonScale, skipForward.enabled);
 


### PR DESCRIPTION
This solution consist in hiding Next button if there is no next asset available. Next asset is obtained by discovery results, therefore we are using that to validate it.