### PR TITLE
[PLAYER-5595] Video fails to seek sometimes on trying to Seek via dragging the pointer

### DIFF
--- a/sdk/react/src/shared/BottomOverlay/BottomOverlay.js
+++ b/sdk/react/src/shared/BottomOverlay/BottomOverlay.js
@@ -446,7 +446,7 @@ export default class BottomOverlay extends React.Component<Props, State> {
   }
 
   renderDefaultProgressBar(playedPercent: number, scrubberBarAccessibilityLabel: string) {
-    const { ad, cuePoints } = this.props;
+    const { ad, cuePoints, markers } = this.props;
     const { accessibilityEnabled, touch, x } = this.state;
 
     return (
@@ -462,7 +462,7 @@ export default class BottomOverlay extends React.Component<Props, State> {
       >
         {this.renderProgressBar(playedPercent)}
         {this.renderMarkersProgressBarOverlayContainer()}
-        {this.renderProgressScrubber(!ad && touch ? this.touchPercent(x) : playedPercent)}
+        {this.renderProgressScrubber(!ad && touch && markers.length > 0 ? this.touchPercent(x) : playedPercent)}
         {this.renderCuePoints(cuePoints)}
       </Animated.View>
     );


### PR DESCRIPTION
This was an issue when you are seeking using the Skin, the progress scrubber and the playhead would not be synchronized. This fix includes adding validation for the existence of markers, since that feature caused changes in the way we calculate position. If we are in touch state and we don't have markers we can still use playhead position for progress scrubber.