### PR TITLE
[PLAYER-5599] App Crashes on trying to seek with Voice Over enabled

### DIFF
--- a/sdk/react/src/shared/BottomOverlay/BottomOverlay.js
+++ b/sdk/react/src/shared/BottomOverlay/BottomOverlay.js
@@ -189,8 +189,7 @@ export default class BottomOverlay extends React.Component<Props, State> {
     }
   }
 
-  onValueChange(value: number) {
-    const { duration, onScrub, playhead } = this.props;
+  onValueChange(value: number, duration: number, onScrub: object, playhead: number) {
 
     let newPlayhead = playhead - value;
 
@@ -470,7 +469,7 @@ export default class BottomOverlay extends React.Component<Props, State> {
 
   renderCompleteProgressBar() {
     const {
-      config, duration, playhead, screenReaderEnabled, shouldShowProgressBar,
+      config, duration, playhead, screenReaderEnabled, shouldShowProgressBar, onScrub
     } = this.props;
     const { cachedPlayhead } = this.state;
 
@@ -497,7 +496,7 @@ export default class BottomOverlay extends React.Component<Props, State> {
           maximumTrackTintColor={maximumTrackTintColor}
           minimumTrackTintColor={minimumTrackTintColor}
           maximumValue={duration}
-          onValueChange={this.onValueChange}
+          onValueChange={(value) => this.onValueChange(value, duration, onScrub, playhead)}
           step={1.0}
           style={{
             flexDirection: 'row',


### PR DESCRIPTION
This fix consists in passing parameters to onValueChange method, since they were not available via React props, causing the app to crash due to undefined values.