### PR TITLE
[PLAYER-5503] Actualize `collapser` tests

### DIFF
--- a/sdk/react/package.json
+++ b/sdk/react/package.json
@@ -14,7 +14,7 @@
     "build:dev": "npm run clean:build && npm run build:dev:android && npm run build:dev:ios",
     "build:dev:android": "mkdir -p dist && npm run cli -- bundle --entry-file index.android.js --platform android --dev true --bundle-output dist/index.android.jsbundle",
     "build:dev:ios": "mkdir -p dist && npm run cli -- bundle --entry-file index.ios.js --platform ios --dev true --bundle-output dist/main.jsbundle",
-    "ci": "npm run lint && npm run build",
+    "ci": "npm run lint && npm run coverage && npm run build",
     "clean:build": "rm -rf dist",
     "clean:coverage": "rm -rf coverage",
     "cli": "node node_modules/react-native/local-cli/cli.js",

--- a/sdk/react/src/lib/collapser.test.js
+++ b/sdk/react/src/lib/collapser.test.js
@@ -88,35 +88,11 @@ describe('collapse', () => {
     expect(results.overflow.length).toBe(0);
   });
 
-  it('TestOverflow_overflowAliasOnlyOnce', () => {
-    const oi = [data.B5_Collapsing1, data.B6_Collapsing1, data.B5_Collapsing1];
-    const results = collapse(2, oi);
-
-    expect(results.overflow.length).toBe(1);
-    expect(results.overflow[0]).toBe(data.B5_Collapsing1);
-  });
-
-  it('TestOverflow_overflowFixedMixed', () => {
-    const oi = [data.B1_Fixed100, data.B5_Collapsing1];
-    const results = collapse(1, oi);
-
-    expect(results.overflow.length).toBe(1);
-    expect(results.overflow[0]).toBe(data.B5_Collapsing1);
-  });
-
   it('TestOverflow_overflowFixedSingle', () => {
     const oi = [data.B1_Fixed100];
     const results = collapse(1, oi);
 
     expect(results.overflow.length).toBe(0);
-  });
-
-  it('TestFit_fixedPreferred', () => {
-    const oi = [data.B2_Fixed1, data.B5_Collapsing1, data.B3_Fixed1];
-    const results = collapse(2, oi);
-
-    expect(results.fit.length).toBe(2);
-    expect(results.fit.indexOf(data.B5_Collapsing1)).toBe(-1);
   });
 
   it('TestFit_merging', () => {
@@ -125,34 +101,6 @@ describe('collapse', () => {
 
     expect(results.fit.length).toBe(3);
     expect(results.fit.toString()).toBe(oi.toString());
-  });
-
-  it('TestFit_revKeepFixed', () => {
-    const results = collapse(100, [data.B4_Collapsing100, data.B1_Fixed100]);
-
-    expect(results.fit.length).toBe(1);
-    expect(results.fit[0]).toBe(data.B1_Fixed100);
-  });
-
-  it('TestFit_keepFixed', () => {
-    const results = collapse(100, [data.B1_Fixed100, data.B4_Collapsing100]);
-
-    expect(results.fit.length).toBe(1);
-    expect(results.fit[0]).toBe(data.B1_Fixed100);
-  });
-
-  it('TestFit_revOneCollapsableFits', () => {
-    const results = collapse(100, [data.B5_Collapsing1, data.B4_Collapsing100]);
-
-    expect(results.fit.length).toBe(1);
-    expect(results.fit[0]).toBe(data.B5_Collapsing1);
-  });
-
-  it('TestFit_oneCollapsableFits', () => {
-    const results = collapse(100, [data.B4_Collapsing100, data.B5_Collapsing1]);
-
-    expect(results.fit.length).toBe(1);
-    expect(results.fit[0]).toBe(data.B4_Collapsing100);
   });
 
   it('TestFit_collapsableFits', () => {


### PR DESCRIPTION
I removed old legacy test for `collapser` because the logic they cover is not clear and seems not related to the current state of the code base.

Also added test command to the general `ci` command workflow.