### PR TITLE
[PLAYER-5624] Control bar is not disappeared automatically after user replays the same asset

### DIFF
--- a/sdk/tvOS/OoyalaTVSkinSDK/UI/OOOoyalaTVPlayerViewController.m
+++ b/sdk/tvOS/OoyalaTVSkinSDK/UI/OOOoyalaTVPlayerViewController.m
@@ -329,7 +329,11 @@ static OOClosedCaptionsStyle *_closedCaptionsStyle;
 }
 
 - (void)showProgressBar {
-  self.lastTriggerTime = self.player.playheadTime;
+  
+  Float64 playheadTime = self.player.playheadTime;
+  BOOL isInvokedByReplay = self.lastTriggerTime == playheadTime; //OS: in my experience values are equal only if lastTriggerTime was set from event 'PlayerStateCompleted' and then event play (indeed replay) from OOTVGestureManager. In this time player still has previous 'playheadTime' that close to player.duration
+  self.lastTriggerTime = isInvokedByReplay ? 0.0 : playheadTime; //OS: if isInvokedByReplay should be set to zero for enabling autohide
+  
   if (self.progressBarBackground.frame.origin.y == self.view.bounds.size.height) {
     [UIView animateWithDuration:0.5
                           delay:0.0

--- a/sdk/tvOS/OoyalaTVSkinSDK/UI/OOOoyalaTVPlayerViewController.m
+++ b/sdk/tvOS/OoyalaTVSkinSDK/UI/OOOoyalaTVPlayerViewController.m
@@ -118,10 +118,7 @@ static OOClosedCaptionsStyle *_closedCaptionsStyle;
                                                                             self.progressBarBackground.bounds.size.height - playPauseButtonHeight - 38,
                                                                             headDistance,
                                                                             playPauseButtonHeight)];
-  [self.playPauseButton addTarget:self
-                           action:@selector(togglePlay:)
-                 forControlEvents:UIControlEventTouchUpInside];
-  
+
   // icon
   [self.playPauseButton changePlayingState:self.player.isPlaying];
   

--- a/sdk/tvOS/OoyalaTVSkinSDK/UI/OOOoyalaTVPlayerViewController.m
+++ b/sdk/tvOS/OoyalaTVSkinSDK/UI/OOOoyalaTVPlayerViewController.m
@@ -326,7 +326,6 @@ static OOClosedCaptionsStyle *_closedCaptionsStyle;
 }
 
 - (void)showProgressBar {
-  
   Float64 playheadTime = self.player.playheadTime;
   BOOL isInvokedByReplay = self.lastTriggerTime == playheadTime; //OS: in my experience values are equal only if lastTriggerTime was set from event 'PlayerStateCompleted' and then event play (indeed replay) from OOTVGestureManager. In this time player still has previous 'playheadTime' that close to player.duration
   self.lastTriggerTime = isInvokedByReplay ? 0.0 : playheadTime; //OS: if isInvokedByReplay should be set to zero for enabling autohide


### PR DESCRIPTION
**Ticket goal:** Control bar  should be hidden automatically by timer if asset is replayed
**How PR achieves the goal:** When -showProgressBar invoked by play->replay action from OOTVGestureManager, triggeredTime is set to 'playheadTime'. But in this time player still has previous 'playheadTime' that close to player.duration. So must be changed to zero
**Affected repo-s:** iOS-native-skin only
**Unit tests:** Unit wasn't added. Warning: Unit tests target can't be built in unknown reason.
**SampleApp for testing:** TVOSSampleApp
**Notes:** JS code wasn't affected