### PR TITLE
[PLAYER-5630] Fix no response for one tap over the seek button

### DIFF
--- a/sdk/react/src/shared/VideoViewPlayPause/VideoViewPlayPause.js
+++ b/sdk/react/src/shared/VideoViewPlayPause/VideoViewPlayPause.js
@@ -91,7 +91,7 @@ export default class VideoViewPlayPause extends React.Component {
       this,
       'sendSummedSkip',
       () => {
-        onSeekPressed(skipCount);
+        onSeekPressed(value);
         this.setState({
           skipCount: 0,
         });

--- a/sdk/react/src/views/AudioView/AudioView.js
+++ b/sdk/react/src/views/AudioView/AudioView.js
@@ -187,7 +187,7 @@ export default class AudioView extends React.Component {
       this,
       'sendSummedSkip',
       () => {
-        this.onSeekPressed(skipCount);
+        this.onSeekPressed(value);
         this.setState({
           skipCount: 0,
         });

--- a/sdk/react/src/views/CastConnectedScreen/CastPlayPauseButtons/CastPlayPauseButtons.js
+++ b/sdk/react/src/views/CastConnectedScreen/CastPlayPauseButtons/CastPlayPauseButtons.js
@@ -91,7 +91,7 @@ export default class CastPlayPauseButtons extends React.Component {
       this,
       'sendSummedSkip',
       () => {
-        onSeekPressed(skipCount);
+        onSeekPressed(value);
         this.setState({ skipCount: 0 });
       },
       VALUES.DELAY_BETWEEN_SKIPS_MS,


### PR DESCRIPTION
The issue was because `onSeekPressed()` has been called with the previous value of `skipCount`. This also fixes [PLAYER-5631]