### PR TITLE
[PLAYER-5644] Geo Blocking error not displayed

### DIFF
--- a/sdk/iOS/OoyalaSkinSDK/OOSkinPlayerObserver.m
+++ b/sdk/iOS/OoyalaSkinSDK/OOSkinPlayerObserver.m
@@ -346,12 +346,8 @@ static NSString *castManagerDidDisconnectDevice = @"castDisconnected";
 
 - (void)bridgeStateChangedNotification:(NSNotification *)notification {
   
-  NSUInteger state = self.player.state;
-  NSNumber *stateObject = notification.userInfo[@"newState"];
-  if (stateObject) {
-    state = stateObject.integerValue;
-  }
-  NSString * stateString = [OOOoyalaPlayerStateConverter playerStateToString:state];
+  NSNumber *stateObject = notification.userInfo[@"newState"] ?: @(self.player.state);
+  NSString * stateString = [OOOoyalaPlayerStateConverter playerStateToString:stateObject.integerValue];
   
   //OS: for live assets need to update frozen time, because playhead that based on current live position was changed since player was paused
   if (self.player.currentItem.live && self.player.state == OOOoyalaPlayerStatePlaying) {

--- a/sdk/iOS/OoyalaSkinSDK/OOSkinPlayerObserver.m
+++ b/sdk/iOS/OoyalaSkinSDK/OOSkinPlayerObserver.m
@@ -345,13 +345,13 @@ static NSString *castManagerDidDisconnectDevice = @"castDisconnected";
 }
 
 - (void)bridgeStateChangedNotification:(NSNotification *)notification {
-  NSString *stateString = [OOOoyalaPlayerStateConverter playerStateToString:self.player.state];
   
+  NSUInteger state = self.player.state;
   NSNumber *stateObject = notification.userInfo[@"newState"];
   if (stateObject) {
-    NSString * stateStringFromUserInfo = [OOOoyalaPlayerStateConverter playerStateToString:stateObject.intValue];
-    stateString = stateStringFromUserInfo;
+    state = stateObject.integerValue;
   }
+  NSString * stateString = [OOOoyalaPlayerStateConverter playerStateToString:state];
   
   //OS: for live assets need to update frozen time, because playhead that based on current live position was changed since player was paused
   if (self.player.currentItem.live && self.player.state == OOOoyalaPlayerStatePlaying) {

--- a/sdk/iOS/OoyalaSkinSDK/OOSkinPlayerObserver.m
+++ b/sdk/iOS/OoyalaSkinSDK/OOSkinPlayerObserver.m
@@ -347,6 +347,12 @@ static NSString *castManagerDidDisconnectDevice = @"castDisconnected";
 - (void)bridgeStateChangedNotification:(NSNotification *)notification {
   NSString *stateString = [OOOoyalaPlayerStateConverter playerStateToString:self.player.state];
   
+  NSNumber *stateObject = notification.userInfo[@"newState"];
+  if (stateObject) {
+    NSString * stateStringFromUserInfo = [OOOoyalaPlayerStateConverter playerStateToString:stateObject.intValue];
+    stateString = stateStringFromUserInfo;
+  }
+  
   //OS: for live assets need to update frozen time, because playhead that based on current live position was changed since player was paused
   if (self.player.currentItem.live && self.player.state == OOOoyalaPlayerStatePlaying) {
     self.liveHelper = (struct LiveAssetHelper) {self.adjustedPlayhead, YES};

--- a/sdk/react/index.android.js
+++ b/sdk/react/index.android.js
@@ -40,9 +40,8 @@ const styles = StyleSheet.create({
 });
 
 class OoyalaSkin extends Component {
-  // note/todo: some of these are more like props, expected to be over-ridden/updated
-  // by the native bridge, and others are used purely on the non-native side.
-  // consider using a leading underscore, or something?
+  // TODO: Some of these are more like props, expected to be over-ridden/updated by the native bridge, and others are
+  // used purely on the non-native side. Consider using a leading underscore, or something?
   state = {
     // states from react
     screenType: SCREEN_TYPES.LOADING_SCREEN,

--- a/sdk/react/index.ios.js
+++ b/sdk/react/index.ios.js
@@ -31,9 +31,8 @@ const styles = StyleSheet.create({
 });
 
 class OoyalaSkin extends Component {
-  // note/todo: some of these are more like props, expected to be over-ridden/updated
-  // by the native bridge, and others are used purely on the non-native side.
-  // consider using a leading underscore, or something?
+  // TODO: Some of these are more like props, expected to be over-ridden/updated by the native bridge, and others are
+  // used purely on the non-native side. Consider using a leading underscore, or something?
   state = {
     // states from react
     screenType: SCREEN_TYPES.LOADING_SCREEN,
@@ -90,7 +89,7 @@ class OoyalaSkin extends Component {
         });
       });
 
-    // TODO: Figure out how to add setAccessibilityFocus method from the ObjC side
+    // TODO: Figure out how to add setAccessibilityFocus method from the ObjC side.
     // AccessibilityInfo.setAccessibilityFocus(1);
   }
 

--- a/sdk/react/src/BridgeListener.js
+++ b/sdk/react/src/BridgeListener.js
@@ -200,7 +200,8 @@ export default class BridgeListener {
     }
   }
 
-  onTimeChange(e) { // todo: naming consistency? playheadUpdate vs. onTimeChange vs. ...
+  // TODO: Naming consistency? playheadUpdate vs. onTimeChange vs. ...
+  onTimeChange(e) {
     this.skin.setState({
       playhead: e.playhead,
       duration: e.duration,

--- a/sdk/react/src/ViewsRenderer.js
+++ b/sdk/react/src/ViewsRenderer.js
@@ -285,7 +285,7 @@ export default class ViewsRenderer {
         lastPressedTime={state.lastPressedTime}
         screenReaderEnabled={state.screenReaderEnabled}
         closedCaptionsLanguage={state.selectedLanguage}
-        // todo: change to boolean showCCButton.
+        // TODO: Change to boolean showCCButton.
         availableClosedCaptionsLanguages={state.availableClosedCaptionsLanguages}
         audioTracksTitles={this.skin.state.audioTracksTitles}
         caption={state.caption}
@@ -500,7 +500,7 @@ export default class ViewsRenderer {
           moreOptionsScreen: this.skin.props.moreOptionsScreen,
           buttons,
           icons: this.skin.props.icons,
-          // TODO: assumes this is how control bar width is calculated everywhere.
+          // TODO: Assumes this is how control bar width is calculated everywhere.
           controlBarWidth: this.skin.state.width - 2 * leftMargin,
         }}
       />

--- a/sdk/react/src/lib/utils.js
+++ b/sdk/react/src/lib/utils.js
@@ -97,12 +97,10 @@ export const stringForErrorCode = (errorCode) => {
   switch (errorCode) {
     case 0:
       // Authorization failed
-      // TODO: Add to language files.
       return 'Authorization failed';
 
     case 1:
       // Authorization response invalid
-      // TODO: Add to language files.
       return 'Invalid Authorization Response';
 
     case 2:
@@ -111,17 +109,14 @@ export const stringForErrorCode = (errorCode) => {
 
     case 3:
       // Content tree response invalid
-      // TODO: Add to language files.
       return 'Content Tree Response Invalid';
 
     case 4:
       // Authorization signature invalid
-      // TODO: Add to language files.
       return 'The signature of the Authorization Response is invalid';
 
     case 5:
       // Content tree next failed
-      // TODO: Add to language files.
       return 'Content Tree Next failed';
 
     case 6:
@@ -134,7 +129,6 @@ export const stringForErrorCode = (errorCode) => {
 
     case 8:
       // Internal error
-      // TODO: Add to language files.
       return 'An internal error occurred';
 
     case 9:
@@ -163,47 +157,38 @@ export const stringForErrorCode = (errorCode) => {
 
     case 15:
       // DRM file download failure
-      // TODO: Add to language files.
       return 'Failed to download a required file during the DRM workflow';
 
     case 16:
       // DRM personalization failure
-      // TODO: Add to language files.
       return 'Failed to complete device personalization during the DRM workflow';
 
     case 17:
       // DRM rights server error
-      // TODO: Add to language files.
       return 'Failed to get rights for asset during the DRM workflow';
 
     case 18:
       // Invalid discovery parameter
-      // TODO: Add to language files.
       return 'The expected discovery parameters are not provided';
 
     case 19:
       // Discovery network error
-      // TODO: Add to language files.
       return 'A discovery network error occurred';
 
     case 20:
       // Discovery response failure
-      // TODO: Add to language files.
       return 'A discovery response error occurred';
 
     case 21:
       // No available streams
-      // TODO: Add to language files.
       return 'No available streams';
 
     case 22:
       // Pcode mismatch
-      // TODO: Add to language files.
       return 'The provided PCode does not match the embed code owner';
 
     case 23:
       // Download error
-      // TODO: Add to language files.
       return 'A download error occurred';
 
     case 24:
@@ -212,37 +197,30 @@ export const stringForErrorCode = (errorCode) => {
 
     case 25:
       //  Advertising id failure
-      // TODO: Add to language files.
       return 'Failed to return the advertising ID';
 
     case 26:
       // Discovery GET failure
-      // TODO: Add to language files.
       return 'Failed to get discovery results';
 
     case 27:
       // Discovery POST failure
-      // TODO: Add to language files.
       return 'Failed to post discovery pins';
 
     case 28:
       // Player format mismatch
-      // TODO: Add to language files.
       return 'Player and player content do not correspond';
 
     case 29:
       // Failed to create VR player
-      // TODO: Add to language files.
       return 'Failed to create VR player';
 
     case 30:
       // Unknown error
-      // TODO: Add to language files.
       return 'An unknown error occurred';
 
     case 31:
       // GeoBlocking access denied
-      // TODO: Add to language files.
       return 'Geo access denied';
 
     default:

--- a/sdk/react/src/views/AdPlaybackScreen/AdPlaybackScreen.js
+++ b/sdk/react/src/views/AdPlaybackScreen/AdPlaybackScreen.js
@@ -64,7 +64,7 @@ export default class AdPlaybackScreen extends React.Component {
   static getDerivedStateFromProps(props) {
     const isPastAutoHideTime = (new Date()).getTime() - props.lastPressedTime > AUTOHIDE_DELAY;
     const doesAdRequireControls = props.ad && props.ad.requireControls;
-    // TODO: IMA Ads UI is still not supported - No way to show UI while allowing Learn More in a clean way
+    // TODO: IMA Ads UI is still not supported - No way to show UI while allowing Learn More in a clean way.
     const isContent = !props.ad;
     const isVisible = props.screenReaderEnabled ? true : !isPastAutoHideTime && (doesAdRequireControls || isContent);
 

--- a/sdk/react/src/views/DiscoveryPanel/DiscoveryPanel.js
+++ b/sdk/react/src/views/DiscoveryPanel/DiscoveryPanel.js
@@ -22,7 +22,7 @@ import CountdownViewiOS from '../../shared/CountdownTimerIos';
 
 import styles from './DiscoveryPanel.styles';
 
-// TODO: read this from config.
+// TODO: Read this from config.
 const animationDuration = 1000;
 
 const rectWidth = 176;

--- a/sdk/react/src/views/MoreOptionScreen/MoreOptionScreen.js
+++ b/sdk/react/src/views/MoreOptionScreen/MoreOptionScreen.js
@@ -194,7 +194,8 @@ export default class MoreOptionScreen extends React.Component {
       case BUTTON_NAMES.SHARE:
         buttonIcon = config.icons.share;
         break;
-      case BUTTON_NAMES.SETTING: // TODO: this doesn't exist in the skin.json?
+      // TODO: This doesn't exist in the skin.json?
+      case BUTTON_NAMES.SETTING:
         buttonIcon = config.icons.setting;
         break;
       case BUTTON_NAMES.STEREOSCOPIC:

--- a/sdk/react/src/views/VideoView/UpNext/UpNext.js
+++ b/sdk/react/src/views/VideoView/UpNext/UpNext.js
@@ -42,7 +42,7 @@ export default class UpNext extends React.Component {
 
     const upNextConfig = config.upNext || {};
 
-    // TODO: Unit test this functionality, there're still some edge cases
+    // TODO: Unit test this functionality, there're still some edge cases.
     if (typeof upNextConfig.timeToShow === 'string') {
       // Support old version of percentage (e.g. '80%')
       if (upNextConfig.timeToShow.indexOf('%') >= 0) {


### PR DESCRIPTION
**Ticket goal:** Show correct error message if geoblocking error occured during playback
**How PR achieves the goal:** in category OOOoyalaPlayer (StateMachine) setter for state used to send wrong (previouse) state with OOOoyalaPlayerStateChangedNotification. 
OOSkinPlayerObserver switched to read state from  notification's user info instead from player directly.

**Affected repo-s:** iOS-SDK + native-Skin-SDK + Skin Config

**Unit tests:** Unit test not added.
**SampleApp for testing**: OOyalaSkin Sample app. 
Asset and other: Please see https://git.corp.ooyala.com/projects/PBA/repos/ios-sdk/pull-requests/561/overview

