### PR TITLE
[PLAYER-5672] Ad timer is not decremented while ad is playing

### DIFF
--- a/sdk/iOS/OoyalaSkinSDK/OOSkinPlayerObserver.m
+++ b/sdk/iOS/OoyalaSkinSDK/OOSkinPlayerObserver.m
@@ -35,6 +35,7 @@
 @property (nonatomic, weak) OOOoyalaPlayer *player;
 @property (nonatomic, weak) OOReactSkinModel *ooReactSkinModel;
 @property (nonatomic) struct LiveAssetHelper liveHelper;
+@property (nonatomic) BOOL isAdPlaying;
 
 @end
 
@@ -119,6 +120,7 @@ static NSString *castManagerDidDisconnectDevice = @"castDisconnected";
   if (self = [super init]) {
     _ooReactSkinModel = ooReactSkinModel;
     _player = player;
+    _isAdPlaying = NO;
     [self addSelfAsObserverToPlayer:player];
   }
   return self;
@@ -273,7 +275,7 @@ static NSString *castManagerDidDisconnectDevice = @"castDisconnected";
   NSNumber *durationNumber  = self.totalDuration;
 
   //OS: pass to JS static playhead time, because playhead and live go forward simultaneously (PLAYER-5491)
-  if (self.player.currentItem.live && self.liveHelper.isOnGuard) {
+  if (self.player.currentItem.live && self.liveHelper.isOnGuard && !self.isAdPlaying) {
     playheadNumber = self.liveHelper.frozenSeekBackTime;
   }
   
@@ -460,15 +462,22 @@ static NSString *castManagerDidDisconnectDevice = @"castDisconnected";
 }
 
 - (void)bridgeAdPodStartedNotification:(NSNotification *)notification {
+  _isAdPlaying = YES;
   [self.ooReactSkinModel sendEventWithName:notification.name body:nil];
 }
 
 - (void)bridgeAdPodCompleteNotification:(NSNotification *)notification {
-  Float64 duration = self.player.duration;
-  Float64 playhead = self.player.playheadTime;
+  _isAdPlaying = NO;
+  NSNumber *playheadNumber  = self.adjustedPlayhead;
+  NSNumber *durationNumber  = self.totalDuration;
   
-  NSDictionary *eventBody = @{durationKey: @(duration),
-                              playheadKey: @(playhead)};
+  //OS: pass to JS static playhead time, because playhead and live go forward simultaneously (PLAYER-5491)
+  if (self.player.currentItem.live && self.liveHelper.isOnGuard) {
+    playheadNumber = self.liveHelper.frozenSeekBackTime;
+  }
+  
+  NSDictionary *eventBody = @{durationKey: durationNumber,
+                              playheadKey: playheadNumber};
   [self.ooReactSkinModel sendEventWithName:notification.name body:eventBody];
   [self.ooReactSkinModel setReactViewInteractionEnabled:YES];
 }

--- a/sdk/iOS/OoyalaSkinSDK/OOSkinPlayerObserver.m
+++ b/sdk/iOS/OoyalaSkinSDK/OOSkinPlayerObserver.m
@@ -462,12 +462,12 @@ static NSString *castManagerDidDisconnectDevice = @"castDisconnected";
 }
 
 - (void)bridgeAdPodStartedNotification:(NSNotification *)notification {
-  _isAdPlaying = YES;
+  self.isAdPlaying = YES;
   [self.ooReactSkinModel sendEventWithName:notification.name body:nil];
 }
 
 - (void)bridgeAdPodCompleteNotification:(NSNotification *)notification {
-  _isAdPlaying = NO;
+  self.isAdPlaying = NO;
   NSNumber *playheadNumber  = self.adjustedPlayhead;
   NSNumber *durationNumber  = self.totalDuration;
   

--- a/sdk/react/src/shared/BottomOverlay/BottomOverlay.js
+++ b/sdk/react/src/shared/BottomOverlay/BottomOverlay.js
@@ -49,7 +49,7 @@ type Props = {
   cuePoints?: ?Array<number>,
   playhead: number,
   duration: number,
-  ad?: ?{},
+  ad?: ?boolean,
   volume: number,
   onPress?: ?(() => void),
   onScrub: (number) => void,
@@ -536,7 +536,7 @@ export default class BottomOverlay extends React.Component<Props, State> {
 
   renderControlBar() {
     const {
-      duration, primaryButton, playhead, volume, live, width, height, fullscreen, isPipActivated, isPipButtonVisible,
+      ad, duration, primaryButton, playhead, volume, live, width, height, fullscreen, isPipActivated, isPipButtonVisible,
       onPress, handleControlsTouch, showWatermark, config, stereoSupported, showMoreOptionsButton, showAudioAndCCButton,
       showPlaybackSpeedButton, inCastMode,
     } = this.props;
@@ -547,6 +547,7 @@ export default class BottomOverlay extends React.Component<Props, State> {
         playhead={playhead}
         duration={duration}
         volume={volume}
+        ad={ad}
         live={live}
         width={width - 2 * leftMargin}
         height={height}

--- a/sdk/react/src/shared/BottomOverlay/BottomOverlay.js
+++ b/sdk/react/src/shared/BottomOverlay/BottomOverlay.js
@@ -49,7 +49,7 @@ type Props = {
   cuePoints?: ?Array<number>,
   playhead: number,
   duration: number,
-  ad?: ?boolean,
+  ad?: ?{},
   volume: number,
   onPress?: ?(() => void),
   onScrub: (number) => void,
@@ -536,18 +536,18 @@ export default class BottomOverlay extends React.Component<Props, State> {
 
   renderControlBar() {
     const {
-      ad, duration, primaryButton, playhead, volume, live, width, height, fullscreen, isPipActivated, isPipButtonVisible,
-      onPress, handleControlsTouch, showWatermark, config, stereoSupported, showMoreOptionsButton, showAudioAndCCButton,
-      showPlaybackSpeedButton, inCastMode,
+      ad, duration, primaryButton, playhead, volume, live, width, height, fullscreen, isPipActivated,
+      isPipButtonVisible, onPress, handleControlsTouch, showWatermark, config, stereoSupported, showMoreOptionsButton,
+      showAudioAndCCButton, showPlaybackSpeedButton, inCastMode,
     } = this.props;
 
     return (
       <ControlBar
+        isAdPlaying={!!ad}
         primaryButton={primaryButton}
         playhead={playhead}
         duration={duration}
         volume={volume}
-        ad={ad}
         live={live}
         width={width - 2 * leftMargin}
         height={height}

--- a/sdk/react/src/shared/BottomOverlay/ControlBar/ControlBar.js
+++ b/sdk/react/src/shared/BottomOverlay/ControlBar/ControlBar.js
@@ -28,6 +28,7 @@ export default class ControlBar extends React.Component {
     volume: PropTypes.number.isRequired,
     onPress: PropTypes.func.isRequired,
     handleControlsTouch: PropTypes.func.isRequired,
+    ad: PropTypes.bool,
     live: PropTypes.shape({}),
     config: PropTypes.shape({}).isRequired,
     stereoSupported: PropTypes.bool,
@@ -47,9 +48,9 @@ export default class ControlBar extends React.Component {
 
   getPlayHeadTimeString = () => {
     const {
-      live, playhead,
+      ad, live, playhead,
     } = this.props;
-    if (live) {
+    if (live && !ad) {
       return live.label;
     }
 
@@ -58,9 +59,9 @@ export default class ControlBar extends React.Component {
 
   getDurationString = () => {
     const {
-      live, duration, playhead,
+      ad, live, duration, playhead,
     } = this.props;
-    if (live) {
+    if (live && !ad) {
       if (live.isLive) {
         return null;
       }
@@ -198,7 +199,7 @@ export default class ControlBar extends React.Component {
 
   render() {
     const {
-      config, fullscreen, handleControlsTouch, height, inCastMode, isPipActivated, isPipButtonVisible, live,
+      ad, config, fullscreen, handleControlsTouch, height, inCastMode, isPipActivated, isPipButtonVisible, live,
       primaryButton, showAudioAndCCButton, showMoreOptionsButton, showPlaybackSpeedButton, stereoSupported, volume,
       width,
     } = this.props;
@@ -211,7 +212,7 @@ export default class ControlBar extends React.Component {
       android: config.controlBar.logo.imageResource.androidResource,
     });
     let liveCircle;
-    if (live) {
+    if (live && !ad) {
       liveCircle = live.isLive ? styles.liveCircleActive : styles.liveCircleNonActive;
     } else {
       liveCircle = null;

--- a/sdk/react/src/shared/BottomOverlay/ControlBar/ControlBar.js
+++ b/sdk/react/src/shared/BottomOverlay/ControlBar/ControlBar.js
@@ -17,6 +17,7 @@ const { AndroidAccessibility } = NativeModules;
 
 export default class ControlBar extends React.Component {
   static propTypes = {
+    isAdPlaying: PropTypes.bool.isRequired,
     width: PropTypes.number.isRequired,
     height: PropTypes.number.isRequired,
     primaryButton: PropTypes.string.isRequired,
@@ -28,7 +29,6 @@ export default class ControlBar extends React.Component {
     volume: PropTypes.number.isRequired,
     onPress: PropTypes.func.isRequired,
     handleControlsTouch: PropTypes.func.isRequired,
-    ad: PropTypes.bool,
     live: PropTypes.shape({}),
     config: PropTypes.shape({}).isRequired,
     stereoSupported: PropTypes.bool,
@@ -48,9 +48,10 @@ export default class ControlBar extends React.Component {
 
   getPlayHeadTimeString = () => {
     const {
-      ad, live, playhead,
+      isAdPlaying, live, playhead,
     } = this.props;
-    if (live && !ad) {
+
+    if (live && !isAdPlaying) {
       return live.label;
     }
 
@@ -59,9 +60,10 @@ export default class ControlBar extends React.Component {
 
   getDurationString = () => {
     const {
-      ad, live, duration, playhead,
+      isAdPlaying, live, duration, playhead,
     } = this.props;
-    if (live && !ad) {
+
+    if (live && !isAdPlaying) {
       if (live.isLive) {
         return null;
       }
@@ -199,9 +201,9 @@ export default class ControlBar extends React.Component {
 
   render() {
     const {
-      ad, config, fullscreen, handleControlsTouch, height, inCastMode, isPipActivated, isPipButtonVisible, live,
-      primaryButton, showAudioAndCCButton, showMoreOptionsButton, showPlaybackSpeedButton, stereoSupported, volume,
-      width,
+      config, fullscreen, handleControlsTouch, height, inCastMode, isAdPlaying, isPipActivated, isPipButtonVisible,
+      live, primaryButton, showAudioAndCCButton, showMoreOptionsButton, showPlaybackSpeedButton, stereoSupported,
+      volume, width,
     } = this.props;
     const { showVolume } = this.state;
 
@@ -211,8 +213,10 @@ export default class ControlBar extends React.Component {
       ios: config.controlBar.logo.imageResource.iosResource,
       android: config.controlBar.logo.imageResource.androidResource,
     });
+
     let liveCircle;
-    if (live && !ad) {
+
+    if (live && !isAdPlaying) {
       liveCircle = live.isLive ? styles.liveCircleActive : styles.liveCircleNonActive;
     } else {
       liveCircle = null;

--- a/sdk/react/src/views/AdPlaybackScreen/AdPlaybackScreen.js
+++ b/sdk/react/src/views/AdPlaybackScreen/AdPlaybackScreen.js
@@ -152,7 +152,7 @@ export default class AdPlaybackScreen extends React.Component {
         cuePoints={cuePoints}
         playhead={playhead}
         duration={duration}
-        ad={ad}
+        ad={true}
         volume={volume}
         live={this.generateLiveObject()}
         onPress={name => this.handlePress(name)}

--- a/sdk/react/src/views/AdPlaybackScreen/AdPlaybackScreen.js
+++ b/sdk/react/src/views/AdPlaybackScreen/AdPlaybackScreen.js
@@ -152,7 +152,7 @@ export default class AdPlaybackScreen extends React.Component {
         cuePoints={cuePoints}
         playhead={playhead}
         duration={duration}
-        ad={true}
+        ad={ad}
         volume={volume}
         live={this.generateLiveObject()}
         onPress={name => this.handlePress(name)}


### PR DESCRIPTION
- For Live Assets, the playhead is set by `liveHelper.frozenSeekBackTime`. When the `AdPlaybackScreen` is set, the playhead is always the initialTime and is not changed by playheadUpdate event.
I added a new boolean flag when the AdPod started (true) and AdPod completed (false), if an ad is playing, the playhead will be updated until the adPodCompleted is fired.