### PR TITLE
[PLAYER-2645] Switch off fullscreen mode if error occurred

### DIFF
--- a/sdk/react/src/ViewsRenderer.js
+++ b/sdk/react/src/ViewsRenderer.js
@@ -93,6 +93,7 @@ export default class ViewsRenderer {
     return (
       <ErrorScreen
         error={this.skin.state.error}
+        fullscreen={this.skin.state.fullscreen}
         localizableStrings={this.skin.props.localization}
         locale={this.skin.props.locale}
         isAudioOnly={this.skin.state.screenType === SCREEN_TYPES.ERROR_SCREEN_AUDIO}

--- a/sdk/react/src/views/ErrorScreen/ErrorScreen.js
+++ b/sdk/react/src/views/ErrorScreen/ErrorScreen.js
@@ -14,6 +14,7 @@ type Props = {
     code?: string,
     description?: string,
   },
+  fullscreen: boolean,
   localizableStrings: {},
   locale: string,
   isAudioOnly: boolean,
@@ -21,6 +22,14 @@ type Props = {
 };
 
 export default class ErrorScreen extends React.Component<Props> {
+  componentDidMount() {
+    const { fullscreen, onPress } = this.props;
+
+    if (fullscreen) {
+      onPress(BUTTON_NAMES.FULLSCREEN);
+    }
+  }
+
   getTitle = () => {
     const { error, locale, localizableStrings } = this.props;
 


### PR DESCRIPTION
If user is in the fullscreen mode and error occurs, then user doesn't have a way to exit from this mode, because Error view doesn't use control bar with fullscreen switching widget. So if error occurs, fullscreen mode will be switched off automatically.