### PR TITLE
[PLAYER-2242] Drop duration and playhead when ad starts

### DIFF
--- a/sdk/react/src/BridgeListener.js
+++ b/sdk/react/src/BridgeListener.js
@@ -223,6 +223,8 @@ export default class BridgeListener {
     Log.log(e);
     this.skin.setState({
       ad: e,
+      duration: 1,
+      playhead: 0,
       screenType: this.skin.state.contentType === CONTENT_TYPES.AUDIO
         ? SCREEN_TYPES.AUDIO_SCREEN : SCREEN_TYPES.VIDEO_SCREEN,
       adOverlay: null,


### PR DESCRIPTION
New ad comes before duration and playhead get updated, so when switching from one ad to another the previous state can be rendered, including Skip button showing. So I tried to fix appropriate ticket by dropping duration and playhead state to the initial one.