### PR TITLE
[PBA-6779] Added proper method for getting activity instance

### DIFF
--- a/sdk/android/skin/src/main/java/com/ooyala/android/skin/OoyalaSkinLayout.java
+++ b/sdk/android/skin/src/main/java/com/ooyala/android/skin/OoyalaSkinLayout.java
@@ -3,6 +3,7 @@ package com.ooyala.android.skin;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.ContextWrapper;
 import android.content.res.Configuration;
 import android.content.res.TypedArray;
 import android.util.AttributeSet;
@@ -89,8 +90,23 @@ public class OoyalaSkinLayout extends FrameLayout implements View.OnSystemUiVisi
       this.windowManager = (WindowManager) getContext().getSystemService(Context.WINDOW_SERVICE);
     }
 
-    final View decorView = ((Activity)getContext()).getWindow().getDecorView();
-    decorView.setOnSystemUiVisibilityChangeListener(this);
+    Activity activity = getActivity(this);
+    if (activity != null) {
+      final View decorView = activity.getWindow().getDecorView();
+      decorView.setOnSystemUiVisibilityChangeListener(this);
+    }
+
+  }
+
+  public static Activity getActivity(View view) {
+    Context context = view.getContext();
+    while (context instanceof ContextWrapper) {
+      if (context instanceof Activity) {
+        return (Activity)context;
+      }
+      context = ((ContextWrapper)context).getBaseContext();
+    }
+    return null;
   }
 
   /**


### PR DESCRIPTION
getContext() could return instance of ContextWrapper at some conditions, in that case old code produce crash, that fix introduce proper method to get activity for view.