### PR TITLE
[PLAYER-4346] Wrap ad playback screen with safe area to avoid iOS notch

### DIFF
--- a/sdk/react/src/views/AdPlaybackScreen/AdPlaybackScreen.js
+++ b/sdk/react/src/views/AdPlaybackScreen/AdPlaybackScreen.js
@@ -1,7 +1,9 @@
 // @flow
 
 import React from 'react';
-import { Image, TouchableHighlight, View } from 'react-native';
+import {
+  Image, SafeAreaView, TouchableHighlight, View,
+} from 'react-native';
 
 import AdBar from './AdBar';
 import { AUTOHIDE_DELAY, UI_SIZES, VALUES } from '../../constants';
@@ -312,23 +314,27 @@ export default class AdPlaybackScreen extends React.Component<Props, State> {
       }
     }
 
+    let children = null;
+
     if (config.adScreen.showControlBar) {
-      return (
-        <View style={styles.adContainer}>
-          {adBar}
-          {this.renderPlaceholder(adIcons)}
+      children = (
+        <React.Fragment>
           {this.renderPlayPause()}
           {this.renderBottomOverlay()}
-        </View>
+        </React.Fragment>
       );
+    } else if (!playing) {
+      children = this.renderPlayPause();
     }
 
     return (
-      <View style={styles.adContainer}>
-        {adBar}
-        {this.renderPlaceholder(adIcons)}
-        {!playing && this.renderPlayPause()}
-      </View>
+      <SafeAreaView style={styles.safeArea}>
+        <View style={styles.root}>
+          {adBar}
+          {this.renderPlaceholder(adIcons)}
+          {children}
+        </View>
+      </SafeAreaView>
     );
   }
 }

--- a/sdk/react/src/views/AdPlaybackScreen/AdPlaybackScreen.styles.js
+++ b/sdk/react/src/views/AdPlaybackScreen/AdPlaybackScreen.styles.js
@@ -3,15 +3,18 @@
 import { StyleSheet } from 'react-native';
 
 export default StyleSheet.create({
-  adContainer: {
+  placeholder: {
+    flex: 1,
+    alignItems: 'stretch',
+    backgroundColor: 'transparent',
+  },
+  root: {
     flex: 1,
     flexDirection: 'column',
     backgroundColor: 'transparent',
     overflow: 'hidden',
   },
-  placeholder: {
+  safeArea: {
     flex: 1,
-    alignItems: 'stretch',
-    backgroundColor: 'transparent',
   },
 });


### PR DESCRIPTION
Safe area adds necessary paddings to avoid notches on iOS devices only. Reference: https://facebook.github.io/react-native/docs/0.59/safeareaview

<img width="200" alt="Screen Shot 2019-07-22 at 8 27 32 PM" src="https://user-images.githubusercontent.com/8770338/61651717-291ce000-acbf-11e9-80be-340b470e4923.png">
