### PR TITLE
[PLAYER-5163] Extra info in Error screen if switching channels for HA assets

### DIFF
--- a/sdk/iOS/OoyalaSkinSDK/OOSkinPlayerObserver.m
+++ b/sdk/iOS/OoyalaSkinSDK/OOSkinPlayerObserver.m
@@ -365,9 +365,14 @@ static NSString *castManagerDidDisconnectDevice = @"castDisconnected";
 - (void)bridgeErrorNotification:(NSNotification *)notification {
   OOOoyalaError *error = self.player.error;
   int errorCode = error ? error.code : -1;
-  NSNumber *code         = @(errorCode);
-  NSString *detail       = self.player.error.description ?: @"";
-  NSDictionary *userInfo = self.player.error.userInfo ?: @{};
+  NSNumber *code          = @(errorCode);
+  NSString *detailRaw     = self.player.error.description ?: @"";
+  NSMutableString *detail = [NSMutableString stringWithString:detailRaw];
+  NSDictionary *userInfo  = self.player.error.userInfo ?: @{};
+
+  if (self.player.currentItem.haEnabled && self.player.currentItem.retryCount > 0) {
+    [detail appendString:@"\n\nWe are trying to reconnect"];
+  }
 
   NSDictionary *eventBody = @{codeKey:        code,
                               descriptionKey: detail,


### PR DESCRIPTION
Added
`We are trying to reconnect` string to the error description if channels are being switched in HA assets.
Conditions to show are:
- asset is HA enabled
- `retryCount` > 0

iOS only