### PR TITLE
[PLAYER-5105] TVOSSwiftSampleApp. Video played duration is showing incorrectly if we seek till end.

### DIFF
--- a/sdk/tvOS/OoyalaTVSkinSDK/UI/OOOoyalaTVPlayerViewController.m
+++ b/sdk/tvOS/OoyalaTVSkinSDK/UI/OOOoyalaTVPlayerViewController.m
@@ -39,6 +39,7 @@
 @property (nonatomic) NSMutableArray *tableList;
 @property (nonatomic) OOOoyalaTVClosedCaptionsView *closedCaptionsView;
 @property (nonatomic, getter=isBufferingAsked) BOOL bufferingAsked;
+@property (nonatomic) NSDateFormatter *dateformatter;
 
 @end
 
@@ -72,6 +73,10 @@ static OOClosedCaptionsStyle *_closedCaptionsStyle;
   _closedCaptionsStyle.textFontName = @"Helvetica";
   _closedCaptionsStyle.backgroundOpacity = 0.4;
   self.optionsViewController = [[OOTVOptionsCollectionViewController alloc] initWithViewController:self];
+  
+  self.dateformatter = [NSDateFormatter new];
+  self.dateformatter.locale = NSLocale.systemLocale;
+  self.dateformatter.timeZone = [NSTimeZone timeZoneForSecondsFromGMT:0];
 }
 
 - (void)viewWillAppear:(BOOL)animated {
@@ -288,9 +293,7 @@ static OOClosedCaptionsStyle *_closedCaptionsStyle;
 }
 
 - (void)timeChangedNotification {
-  [self updateTimeWithDuration:self.player.duration
-                      playhead:self.player.playheadTime];
-  
+  [self updateTimeWithDuration:self.player.duration playhead:self.player.playheadTime];
   [self updateBottomBarsWithPlayheadTime:self.player.playheadTime];
   
   // We refresh CC view everytime player change state
@@ -300,10 +303,7 @@ static OOClosedCaptionsStyle *_closedCaptionsStyle;
 #pragma mark - Private functions
 
 - (void)updateTimeWithDuration:(CGFloat)duration playhead:(CGFloat)playhead {
-  NSDateFormatter *dateformat = [NSDateFormatter new];
-  dateformat.dateFormat = duration < 3600 ? @"mm:ss" : @"H:mm:ss";
-  dateformat.locale = NSLocale.systemLocale;
-  dateformat.timeZone = [NSTimeZone timeZoneForSecondsFromGMT:0];
+  self.dateformatter = (duration < 3600) ? @"mm:ss" : @"H:mm:ss";
   self.playheadLabel.text = [NSString stringWithFormat:@"%@", [dateformat stringFromDate:[NSDate dateWithTimeIntervalSince1970:playhead]]];
   self.durationLabel.text = [NSString stringWithFormat:@"%@", [dateformat stringFromDate:[NSDate dateWithTimeIntervalSince1970:duration]]];
   

--- a/sdk/tvOS/OoyalaTVSkinSDK/UI/OOOoyalaTVPlayerViewController.m
+++ b/sdk/tvOS/OoyalaTVSkinSDK/UI/OOOoyalaTVPlayerViewController.m
@@ -273,6 +273,11 @@ static OOClosedCaptionsStyle *_closedCaptionsStyle;
       case OOOoyalaPlayerStateCompleted:
         [self.playPauseButton showReplayIcon];
         [self showProgressBar];
+        //OS: PLAYER-4160. When playback completed, 'playheadTime' is not equal to 'duration' (duration is rounded to higher digit). It's drawed as progress bar is not matches end of track and playheadTime not equal to duration.
+        Float64 duration = self.player.duration;
+        self.dateformatter.dateFormat = (duration < 3600) ? @"mm:ss" : @"H:mm:ss";
+        self.playheadLabel.text = [NSString stringWithFormat:@"%@", [self.dateformatter stringFromDate:[NSDate dateWithTimeIntervalSince1970:duration]]];
+        [self updateBottomBarsWithPlayheadTime:duration];
         break;
       case OOOoyalaPlayerStateReady:
         [self stopActivityIndicator];
@@ -303,9 +308,9 @@ static OOClosedCaptionsStyle *_closedCaptionsStyle;
 #pragma mark - Private functions
 
 - (void)updateTimeWithDuration:(CGFloat)duration playhead:(CGFloat)playhead {
-  self.dateformatter = (duration < 3600) ? @"mm:ss" : @"H:mm:ss";
-  self.playheadLabel.text = [NSString stringWithFormat:@"%@", [dateformat stringFromDate:[NSDate dateWithTimeIntervalSince1970:playhead]]];
-  self.durationLabel.text = [NSString stringWithFormat:@"%@", [dateformat stringFromDate:[NSDate dateWithTimeIntervalSince1970:duration]]];
+  self.dateformatter.dateFormat = (duration < 3600) ? @"mm:ss" : @"H:mm:ss";
+  self.playheadLabel.text = [NSString stringWithFormat:@"%@", [self.dateformatter stringFromDate:[NSDate dateWithTimeIntervalSince1970:playhead]]];
+  self.durationLabel.text = [NSString stringWithFormat:@"%@", [self.dateformatter stringFromDate:[NSDate dateWithTimeIntervalSince1970:duration]]];
   
   [self.playPauseButton changePlayingState:self.player.isPlaying];
   

--- a/sdk/tvOS/OoyalaTVSkinSDK/Widgets/ClosedCaptions/OOOoyalaTVClosedCaptionsView.m
+++ b/sdk/tvOS/OoyalaTVSkinSDK/Widgets/ClosedCaptions/OOOoyalaTVClosedCaptionsView.m
@@ -199,7 +199,7 @@ static CGFloat arbitraryScalingFactor = 1.2;
     }
   }
   // If the presentation is PaintOn then the text should be added one by one later in different threads.
-  if (self.style.presentation != OOClosedCaptionPaintOn) {
+  if (self.style.presentation != OOClosedCaptionPresentationPaintOn) {
     self.textView.text = resultText;
   } else {
     self.textView.text = @""; // clean the layer before next text
@@ -220,7 +220,7 @@ static CGFloat arbitraryScalingFactor = 1.2;
                                    frameWidth,
                                    linePadding * 2 + maxLineSize.height * lineCount);
 
-  if (self.style.presentation == OOClosedCaptionPopOn) {
+  if (self.style.presentation == OOClosedCaptionPresentationPopOn) {
     self.textView.textAlignment = NSTextAlignmentCenter;
   }
   self.backgroundView.frame = self.textView.frame;

--- a/sdk/tvOS/OoyalaTVSkinSDK/Widgets/ClosedCaptions/OOTVClosedCaptionsTextView.m
+++ b/sdk/tvOS/OoyalaTVSkinSDK/Widgets/ClosedCaptions/OOTVClosedCaptionsTextView.m
@@ -35,7 +35,7 @@ static CGFloat arbitraryScalingFactor = 1.2;
     self.userInteractionEnabled = NO;
     // This is important!!!! make sure shadow can be shown
     self.backgroundColor = UIColor.clearColor;
-    if (style.presentation != OOClosedCaptionPaintOn) {
+    if (style.presentation != OOClosedCaptionPresentationPaintOn) {
       self.textAlignment = NSTextAlignmentCenter;
     }
     if (&MACaptionAppearanceCopyForegroundColor) {


### PR DESCRIPTION
**Ticket goal:** Fix time labels and play/pause button when user performed seek to end
**How PR achieves the goal:** Original bug is not reproducible anymore. But I fixed bug reported in PLAYER-4160 for iOS-platform.
When playback completed, 'playheadTime' is not equal to 'duration' (duration is rounded to higher digit). It's drawed as progress bar is not matches end of track and playheadTime not equal to duration. 
Now, when VC receives stateChangedNotification and state is `OOOoyalaPlayerStateCompleted` it corrects time labels.
**Affected repo-s:** native-skin sdk + SampleApps
**Unit tests:** Unit test not added.
**SampleApp for testing**: mentioned in ticket description