### PR TITLE
[PBA-6858] Closed Caption didn't show up appropriately

### DIFF
--- a/sdk/android/skin/src/main/java/com/ooyala/android/skin/notification/video/VideoTimeChangedNotificationHandler.java
+++ b/sdk/android/skin/src/main/java/com/ooyala/android/skin/notification/video/VideoTimeChangedNotificationHandler.java
@@ -39,11 +39,11 @@ public class VideoTimeChangedNotificationHandler extends BaseTimeChangedNotifica
       Caption caption = cc.getCaption(language, currentTime);
       if (caption != null) {
         captionText = caption.getText();
+
+        WritableMap params = Arguments.createMap();
+        params.putString("text", captionText);
+        layoutController.sendEvent(OoyalaSkinPlayerObserver.CLOSED_CAPTIONS_UPDATE_EVENT, params);
       }
     }
-
-    WritableMap params = Arguments.createMap();
-    params.putString("text", captionText);
-    layoutController.sendEvent(OoyalaSkinPlayerObserver.CLOSED_CAPTIONS_UPDATE_EVENT, params);
   }
 }


### PR DESCRIPTION
VideoTimeChangedNotificationHandler conflicted with Manifest CC so CLOSED_CAPTIONS_UPDATE_EVENT is sent just in the case the caption text exists